### PR TITLE
Add docker build stage and use Debian Buster as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM node:12.16.3-alpine
-
-# install simple http server for serving static content
-RUN yarn global add http-server
+FROM node:12.16.3-buster-slim AS umbrel-dashboard-builder
 
 # make the 'app' folder the current working directory
 WORKDIR /app
@@ -27,5 +24,11 @@ RUN yarn build
 # copy index.html to 404.html as http-server serves 404.html on all non "/" routes
 RUN cp ./dist/index.html ./dist/404.html
 
+FROM node:12.16.3-buster-slim AS umbrel-dashboard
+
+RUN yarn global add http-server
+
+COPY --from=umbrel-dashboard-builder /app/dist/ /dist
+
 EXPOSE 3004
-CMD [ "http-server", "-p 3004", "dist" ]
+CMD [ "http-server", "-p 3004", "/dist" ]


### PR DESCRIPTION
Reduces final image size from 414MB to 169MB by using a disposable build stage to build the project.

```
$ docker images umbrel-dashboard
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
umbrel-dashboard    slim                ffbb89f25bd6        6 minutes ago       169MB
umbrel-dashboard    master              9a19d09efd79        50 minutes ago      414MB
```

It is possible to get a smaller ~100MB image by using `debian:buster-slim` as a base and manually pulling in only `node` and `http-server` into the image.

However this gives less cumulative advantage. Even though `debian:buster-slim`+`node` is smaller than `node:12.16.3-buster-slim`, it will result in duplicate Node.js layers for each Node.js Docker image.

If we use the slightly larger `node:12.16.3-buster-slim` image, we can share it across all Node.js projects. It also depends on `debian:buster-slim` which in turn is shared with many other images.