### PR TITLE
Add unneeded files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 Dockerfile
+node_modules
+.git
+.github


### PR DESCRIPTION
This will reduce the amount of fluff we add to the build.

It also means changing the Dockerfile won't invalidate almost the entire build since it was previously invalidating everything below `COPY. .`.

I also excluded `node_modules` so we can be sure we get a fresh install of dependencies inside the image.