### PR TITLE
Add power cycle functionality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,8 @@
 <template>
   <div id="app">
     <transition name="loading" mode>
-      <loading v-if="loading" :text="loadingText" :progress="loadingProgress"></loading>
+      <shutdown v-if="hasShutdown"></shutdown>
+      <loading v-else-if="loading" :text="loadingText" :progress="loadingProgress"></loading>
       <!-- component matched by the route will render here -->
       <router-view v-else></router-view>
     </transition>
@@ -14,6 +15,7 @@
 
 <script>
 import { mapState } from "vuex";
+import Shutdown from "@/components/Shutdown";
 import Loading from "@/components/Loading";
 
 export default {
@@ -28,6 +30,7 @@ export default {
   },
   computed: {
     ...mapState({
+      hasShutdown: state => state.system.hasShutdown,
       isManagerApiOperational: state => state.system.managerApi.operational,
       isApiOperational: state => state.system.api.operational,
       isBitcoinOperational: state => state.bitcoin.operational,
@@ -153,7 +156,8 @@ export default {
     window.clearInterval(this.loadingInterval);
   },
   components: {
-    Loading
+    Loading,
+    Shutdown
   }
 };
 </script>

--- a/src/components/Shutdown.vue
+++ b/src/components/Shutdown.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="d-flex flex-column align-items-center justify-content-center min-vh100 p-2">
+    <img alt="Umbrel" src="@/assets/logo.svg" class="mb-5 logo" />
+
+    <span class="text-muted w-75 text-center">
+      <small>Shutdown complete. You can close this window now.</small>
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {};
+  },
+  created() {},
+  methods: {},
+  components: {}
+};
+</script>
+
+<style lang="scss" scoped>
+.logo {
+  height: 20vh;
+  max-height: 200px;
+  width: auto;
+  filter: grayscale(100%);
+}
+</style>

--- a/src/helpers/delay.js
+++ b/src/helpers/delay.js
@@ -1,0 +1,1 @@
+export default ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -88,13 +88,19 @@ const actions = {
     commit("setHasShutDown", false);
 
     // Shutting down
+    const result = await API.get(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/shutdown`);
+    if (!result) {
+      throw new Error('Shutdown request failed');
+    }
+
     commit("setShuttingDown", true);
 
-    // API call here
+    // TODO: We could poll the API until it becomes unresponsive
+    // to see when shutdown has completed.
     await delay(3000);
 
     // Not shutting down anymore because
-    // the system has shut down successfully 
+    // the system has shut down successfully
     commit("setShuttingDown", false);
     commit("setHasShutDown", true);
   },
@@ -110,7 +116,7 @@ const actions = {
     await delay(3000);
 
     // Not rebooting down anymore because
-    // the system has rebooted successfully 
+    // the system has rebooted successfully
     commit("setRebooting", false);
     commit("setHasRebooted", true);
   }

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -117,7 +117,7 @@ const actions = {
 
     // TODO: We could poll the API until it becomes unresponsive
     // and then responsive again to see when shutdown has completed.
-    delay(3000).then(() => {
+    delay(30000).then(() => {
       commit("setRebooting", false);
       commit("setHasRebooted", true);
     });

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -108,15 +108,19 @@ const actions = {
     commit("setHasRebooted", false);
 
     // Rebooting
+    const result = await API.get(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/reboot`);
+    if (!result) {
+      throw new Error('Reboot request failed');
+    }
+
     commit("setRebooting", true);
 
-    // API call here
-    await delay(3000);
-
-    // Not rebooting down anymore because
-    // the system has rebooted successfully
-    commit("setRebooting", false);
-    commit("setHasRebooted", true);
+    // TODO: We could poll the API until it becomes unresponsive
+    // and then responsive again to see when shutdown has completed.
+    delay(3000).then(() => {
+      commit("setRebooting", false);
+      commit("setHasRebooted", true);
+    });
   }
 };
 

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -88,7 +88,7 @@ const actions = {
     commit("setHasShutDown", false);
 
     // Shutting down
-    const result = await API.get(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/shutdown`);
+    const result = await API.post(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/shutdown`);
     if (!result) {
       throw new Error('Shutdown request failed');
     }
@@ -108,7 +108,7 @@ const actions = {
     commit("setHasRebooted", false);
 
     // Rebooting
-    const result = await API.get(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/reboot`);
+    const result = await API.post(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/reboot`);
     if (!result) {
       throw new Error('Reboot request failed');
     }

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -1,8 +1,13 @@
 import API from "@/helpers/api";
+import delay from "@/helpers/delay";
 
 // Initial state
 const state = () => ({
   loading: true,
+  rebooting: false,
+  hasRebooted: false,
+  shuttingDown: false,
+  hasShutdown: false,
   unit: "sats", //sats or btc
   api: {
     operational: false,
@@ -28,6 +33,18 @@ const mutations = {
   },
   setLoading(state, loading) {
     state.loading = loading;
+  },
+  setRebooting(state, rebooting) {
+    state.rebooting = rebooting;
+  },
+  setHasRebooted(state, hasRebooted) {
+    state.hasRebooted = hasRebooted;
+  },
+  setShuttingDown(state, shuttingDown) {
+    state.shuttingDown = shuttingDown;
+  },
+  setHasShutDown(state, hasShutdown) {
+    state.hasShutdown = hasShutdown;
   },
   setOnionAddress(state, address) {
     state.onionAddress = address;
@@ -64,6 +81,38 @@ const actions = {
   async getOnionAddress({ commit }) {
     const address = await API.get(`${process.env.VUE_APP_MANAGER_API_URL}/v1/system/dashboard-hidden-service`);
     commit("setOnionAddress", address);
+  },
+  async shutdown({ commit }) {
+
+    // Reset any cached hasShutdown value from previous shutdown
+    commit("setHasShutDown", false);
+
+    // Shutting down
+    commit("setShuttingDown", true);
+
+    // API call here
+    await delay(3000);
+
+    // Not shutting down anymore because
+    // the system has shut down successfully 
+    commit("setShuttingDown", false);
+    commit("setHasShutDown", true);
+  },
+  async reboot({ commit }) {
+
+    // Reset any cached hasRebooted value from previous reboot
+    commit("setHasRebooted", false);
+
+    // Rebooting
+    commit("setRebooting", true);
+
+    // API call here
+    await delay(3000);
+
+    // Not rebooting down anymore because
+    // the system has rebooted successfully 
+    commit("setRebooting", false);
+    commit("setHasRebooted", true);
   }
 };
 

--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -97,12 +97,10 @@ const actions = {
 
     // TODO: We could poll the API until it becomes unresponsive
     // to see when shutdown has completed.
-    await delay(3000);
-
-    // Not shutting down anymore because
-    // the system has shut down successfully
-    commit("setShuttingDown", false);
-    commit("setHasShutDown", true);
+    delay(3000).then(() => {
+      commit("setShuttingDown", false);
+      commit("setHasShutDown", true);
+    });
   },
   async reboot({ commit }) {
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -117,7 +117,6 @@
               <b-modal
                 ref="reboot-modal"
                 title="Are you sure?"
-                centered
                 no-close-on-backdrop
                 no-close-on-esc
                 @ok="reboot($event)"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -98,7 +98,7 @@
             <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
               <div>
                 <span class="d-block">Shutdown</span>
-                <small class="d-block" style="opacity: 0.4">Power off the system</small>
+                <small class="d-block" style="opacity: 0.4">Power off your Umbrel</small>
               </div>
               <b-button
                 variant="danger"
@@ -110,7 +110,7 @@
             <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
               <div>
                 <span class="d-block">Reboot</span>
-                <small class="d-block" style="opacity: 0.4">Reboot the system</small>
+                <small class="d-block" style="opacity: 0.4">Reboot your Umbrel</small>
               </div>
 
               <b-button variant="danger" @click="rebootPrompt">Reboot</b-button>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -270,11 +270,10 @@ export default {
       this.$refs["reboot-modal"].show();
     },
     async reboot(event) {
-      if (this.hasRebooted) {
-        return;
+      if (!this.hasRebooted) {
+        event.preventDefault();
+        await this.$store.dispatch("system/reboot");
       }
-      event.preventDefault();
-      await this.$store.dispatch("system/reboot");
     }
   },
   watch: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -98,7 +98,7 @@
             <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
               <div>
                 <span class="d-block">Shutdown</span>
-                <small class="d-block" style="opacity: 0.4">Power off your Umbrel</small>
+                <small class="d-block text-muted">Power off your Umbrel</small>
               </div>
               <b-button variant="danger" @click="shutdownPrompt">Shutdown</b-button>
             </div>
@@ -107,7 +107,7 @@
             <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
               <div>
                 <span class="d-block">Reboot</span>
-                <small class="d-block" style="opacity: 0.4">Reboot your Umbrel</small>
+                <small class="d-block text-muted">Reboot your Umbrel</small>
               </div>
 
               <b-button variant="danger" @click="rebootPrompt">Reboot</b-button>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -253,26 +253,24 @@ export default {
         return;
       }
 
-      this.$bvToast.toast(`System is shutting down`, {
-        title: "Your Umbrel will become unresponsive soon",
+      // Shutdown request
+      let toastText = '';
+      let toastOptions = {
         autoHideDelay: 3000,
-        variant: "warning",
         solid: true,
         toaster: "b-toaster-bottom-right"
-      });
-
-      // Shutdown request
+      };
       try {
         await this.$store.dispatch("system/shutdown");
+        toastText = "System is shutting down";
+        toastOptions.title = "Your Umbrel will become unresponsive soon";
+        toastOptions.variant = "warning";
       } catch (e) {
-        this.$bvToast.toast(`Shutdown failed`, {
-          title: "Something went wrong and Umbrel was not able to shutdown",
-          autoHideDelay: 3000,
-          variant: "danger",
-          solid: true,
-          toaster: "b-toaster-bottom-right"
-        });
+        toastText = "Shutdown failed";
+        toastOptions.title = "Something went wrong and Umbrel was not able to shutdown";
+        toastOptions.variant = "danger";
       }
+      this.$bvToast.toast(toastText, toastOptions);
     },
     rebootPrompt() {
       // Reset any cached hasRebooted value from previous reboot

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -280,7 +280,17 @@ export default {
     async reboot(event) {
       if (!this.hasRebooted) {
         event.preventDefault();
-        await this.$store.dispatch("system/reboot");
+        try {
+          await this.$store.dispatch("system/reboot");
+        } catch (e) {
+          this.$bvToast.toast("Reboot failed", {
+            title: "Something went wrong and Umbrel was not able to reboot",
+            autoHideDelay: 3000,
+            variant: "danger",
+            solid: true,
+            toaster: "b-toaster-bottom-right"
+          });
+        }
       }
     }
   },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -116,7 +116,7 @@
                 :title="hasRebooted ? 'Successfully rebooted' : 'Are you sure?'"
                 no-close-on-backdrop
                 no-close-on-esc
-                @ok.prevent="reboot()"
+                @ok="reboot($event)"
                 :cancel-disabled="isRebooting || hasRebooted"
                 :ok-disabled="isRebooting"
               >
@@ -269,10 +269,11 @@ export default {
       this.$store.commit("system/setHasRebooted", false);
       this.$refs["reboot-modal"].show();
     },
-    async reboot() {
+    async reboot(event) {
       if (this.hasRebooted) {
         return;
       }
+      event.preventDefault();
       await this.$store.dispatch("system/reboot");
     }
   },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -127,7 +127,10 @@
                   <p>Your Umbrel will be unresponsive untill it's back online.</p>
                 </div>
                 <div v-else>
-                  <p v-if="isRebooting">Your Umbrel is rebooting.</p>
+                  <p v-if="isRebooting">
+                    <b-spinner small label="Small Spinner"></b-spinner>
+                    Your Umbrel is rebooting.
+                  </p>
                   <p v-else>Successfully rebooted, your Umbrel is back online!</p>
                 </div>
               </b-modal>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -213,7 +213,7 @@ export default {
           this.$bvToast.toast(error.response.data, {
             title: "Error",
             autoHideDelay: 3000,
-            variant: "warning",
+            variant: "danger",
             solid: true,
             toaster: "b-toaster-bottom-right"
           });

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -262,7 +262,17 @@ export default {
       });
 
       // Shutdown request
-      await this.$store.dispatch("system/shutdown");
+      try {
+        await this.$store.dispatch("system/shutdown");
+      } catch (e) {
+        this.$bvToast.toast(`Shutdown failed`, {
+          title: "Something went wrong and Umbrel was not able to shutdown",
+          autoHideDelay: 3000,
+          variant: "danger",
+          solid: true,
+          toaster: "b-toaster-bottom-right"
+        });
+      }
     },
     rebootPrompt() {
       // Reset any cached hasRebooted value from previous reboot


### PR DESCRIPTION
Related:
- https://github.com/getumbrel/umbrel/pull/28
- https://github.com/getumbrel/umbrel-manager/pull/21

I've just stubbed out the API for now.

Would be good to get some feedback on the code. I've not used Vue before so let me know if there's a better way to do anything.

The reboot modal can't be closed while the device is rebooting to keep the user there until everything is running again.

Also the UI fades out on shutdown to make sure they don't try to interact with the UI while Umbrel is down.

Demo:

![umbrel-power-demo-1024](https://user-images.githubusercontent.com/2123375/87224813-98994d00-c3b2-11ea-810a-3e8ea123a762.gif)