### PR TITLE
Wait 60s for reboot

### DIFF
--- a/src/store/modules/system.js
+++ b/src/store/modules/system.js
@@ -117,7 +117,7 @@ const actions = {
 
     // TODO: We could poll the API until it becomes unresponsive
     // and then responsive again to see when shutdown has completed.
-    delay(30000).then(() => {
+    delay(60000).then(() => {
       commit("setRebooting", false);
       commit("setHasRebooted", true);
     });


### PR DESCRIPTION
Pi is sloooow. The dashboard optimistically shows that the reboot is complete after 30s of inactivity, even though it can take a few more seconds for the services to get back up. 