### PR TITLE
Fix Tor Browser capitalisation

### DIFF
--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -144,7 +144,7 @@ export default {
         {
           heading: "access from anywhere",
           text:
-            "Even when you're not on your home network, you can access your Umbrel using Tor browser on the following URL"
+            "Even when you're not on your home network, you can access your Umbrel using Tor Browser on the following URL"
         },
         {
           heading: "one last thing",


### PR DESCRIPTION
Should be "Tor Browser" not "Tor browser".

Also we could probably just drop the word "browser" completely and have:

>Even when you're not on your home network, you can access your Umbrel using Tor on the following URL

Tor Browser is not technically a requirement, only Tor. Any browser can be configured to use Tor.