### PR TITLE
Fixed typo in onboarding

### DIFF
--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -161,7 +161,7 @@ export default {
         {
           heading: "note down your secret words",
           text:
-            'Remember, there is no "forget password" button. You will need these 24 words to recover your Umbrel.'
+            'Remember, there is no "forgot password" button. You will need these 24 words to recover your Umbrel.'
         },
         {
           heading: "access from anywhere",


### PR DESCRIPTION
Corrected a typo in the onboarding screen: changed "forget password" to "forgot password" for (1) grammar and (2) consistency with the language in the settings page.