### PR TITLE
Document and ignore local dev env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ yarn-error.log*
 *.sln
 *.sw?
 
+# Local dev env
+.env.development
+
 # Local todo file
 .todo

--- a/README.md
+++ b/README.md
@@ -27,12 +27,19 @@ yarn
 ```
 
 ### Step 2. Set environment variables
-Set the following environment variables in `.env` file of the project's root.
+The following environment variables are set in `.env` file of the project's root:
 
 | Variable | Description | Default |
 | ------------- | ------------- | ------------- |
 | `VUE_APP_MANAGER_API_URL` | URL of [`umbrel-manager`](https://github.com/getumbrel/umbrel-manager) API | `http://localhost:3006` |
 | `VUE_APP_MIDDLEWARE_API_URL` | URL of [`umbrel-middleware`](https://github.com/getumbrel/umbrel-middleware) API | `http://localhost:3005` |
+
+If you want to change the local development environment (e.g. to use you local umbrel instance), create the `.env.development` with the following content:
+
+```sh
+VUE_APP_MIDDLEWARE_API_URL=http://umbrel.local/api
+VUE_APP_MANAGER_API_URL=http://umbrel.local/manager-api
+```
 
 ### Step 3. Run dashboard
 ```sh


### PR DESCRIPTION
This way changes to the local dev environment do not change `.env`, which is part of the version control.
It gives an easy way to override the dev settings without messing with otherwise defined env vars.