### PR TITLE
Filter logs for bitcoin and lnd

### DIFF
--- a/src/views/Bitcoin.vue
+++ b/src/views/Bitcoin.vue
@@ -23,44 +23,40 @@
             <span class="d-block text-muted">{{ version ? `v${version}` : "..." }}</span>
           </div>
         </div>
-        <a href="#" @click.prevent="showConnectionInfo">
-          <svg
-            width="18"
-            height="4"
-            viewBox="0 0 18 4"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-              fill="#C3C6D1"
-            />
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-              fill="#C3C6D1"
-            />
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-              fill="#C3C6D1"
-            />
-          </svg>
-        </a>
-        <!-- <div>
-          <b-dropdown variant="link" toggle-class="text-decoration-none p-0" no-caret right>
-            <template v-slot:button-content>
-            </template>
-            <b-dropdown-item href="#" disabled>Check for update</b-dropdown-item>
-            <b-dropdown-item href="#" disabled>View information</b-dropdown-item>
-            <b-dropdown-divider />
-            <b-dropdown-item variant="danger" href="#" disabled>Stop Bitcoin Core</b-dropdown-item>
-          </b-dropdown>
-        </div>-->
+        <b-dropdown variant="link" toggle-class="text-decoration-none p-0" no-caret right>
+          <template v-slot:button-content>
+            <svg
+              width="18"
+              height="4"
+              viewBox="0 0 18 4"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
+                fill="#C3C6D1"
+              />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
+                fill="#C3C6D1"
+              />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
+                fill="#C3C6D1"
+              />
+            </svg>
+          </template>
+          <b-dropdown-item href="#" @click.prevent="showConnectionInfo">Connect</b-dropdown-item>
+          <b-dropdown-item href="/logs/?filter=umbrel+bitcoin" target="_blank">View logs</b-dropdown-item>
+          <!-- <b-dropdown-divider /> -->
+          <!-- <b-dropdown-item variant="danger" href="#" disabled>Stop Bitcoin Core</b-dropdown-item> -->
+        </b-dropdown>
       </div>
     </div>
 

--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -30,43 +30,40 @@
           </div>
         </div>
         <div>
-          <a href="#" @click.prevent="showNodeInfo">
-            <svg
-              width="18"
-              height="4"
-              viewBox="0 0 18 4"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                fill="#C3C6D1"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                fill="#C3C6D1"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                fill="#C3C6D1"
-              />
-            </svg>
-          </a>
-          <!-- <b-dropdown variant="link" toggle-class="text-decoration-none p-0" no-caret right> -->
-          <!-- <template v-slot:button-content>
-              
+          <b-dropdown variant="link" toggle-class="text-decoration-none p-0" no-caret right>
+            <template v-slot:button-content>
+              <svg
+                width="18"
+                height="4"
+                viewBox="0 0 18 4"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
+                  fill="#C3C6D1"
+                />
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
+                  fill="#C3C6D1"
+                />
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
+                  fill="#C3C6D1"
+                />
+              </svg>
             </template>
-          <b-dropdown-item href="#" @click="showNodeInfo">Node information</b-dropdown-item>-->
-          <!-- <b-dropdown-item href="#" disabled>Check for updates</b-dropdown-item> -->
-          <!-- <b-dropdown-divider /> -->
-          <!-- <b-dropdown-item variant="danger" href="#" disabled>Stop Lightning</b-dropdown-item> -->
-          <!-- </b-dropdown> -->
+            <b-dropdown-item href="#" @click.prevent="showNodeInfo">View info</b-dropdown-item>
+            <b-dropdown-item href="/logs/?filter=umbrel+lnd" target="_blank">View logs</b-dropdown-item>
+            <!-- <b-dropdown-divider /> -->
+            <!-- <b-dropdown-item variant="danger" href="#" disabled>Stop LND</b-dropdown-item> -->
+          </b-dropdown>
           <b-modal id="node-info-modal" ref="node-info-modal" size="lg" centered hide-footer>
             <template v-slot:modal-header="{ close }">
               <div class="px-2 px-sm-3 pt-2 d-flex justify-content-between w-100">

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -33,6 +33,7 @@
             </svg>
           </template>
           <b-dropdown-item href="#" v-b-modal.seed-modal>View secret words</b-dropdown-item>
+          <b-dropdown-item href="/logs" target="_blank">View system logs</b-dropdown-item>
         </b-dropdown>
       </div>
     </div>
@@ -230,17 +231,6 @@
                   <p>Don't forget to login to your dashboard after the restart is complete (required only once after a restart for your Umbrel to be online).</p>
                 </div>
               </b-modal>
-            </div>
-          </div>
-          <div class="pt-0">
-            <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
-              <div>
-                <span class="d-block">Logs</span>
-                <small class="d-block" style="opacity: 0.4">View system logs in real-time</small>
-              </div>
-              <a class="card-link mr-2" href="/logs" target="_blank">
-                <small class="text-uppercase">View</small>
-              </a>
             </div>
           </div>
           <div class="px-4 pb-4">


### PR DESCRIPTION
This allows user to filter and view logs for only bitcoin and lnd, and is especially useful for us when trying to fetch logs for a either of these services without having middleware/manager spam the entire log stream. 

The logs in settings have also been moved to the 3-dot menu for consistency. 

![image](https://user-images.githubusercontent.com/10330103/92586634-25c62880-f2b4-11ea-9e66-ac74414cf740.png)
