### PR TITLE
Move change password inputs to a dedicated modal

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -118,53 +118,85 @@
         </card-widget>
       </b-col>
       <b-col col cols="12" md="6" xl="4">
-        <card-widget header="Change password" :loading="isChangingPassword">
-          <div class="px-4 pb-2">
-            <label class="sr-onlsy" for="input-withdrawal-amount">Current password</label>
-            <input-password
-              v-model="currentPassword"
-              ref="password"
-              inputGroupClass="neu-input-group"
-              :inputClass="[
-                isIncorrectPassword ? 'incorrect-password' : '',
-                'form-control form-control-lg neu-input w-100'
-              ]"
-              :disabled="isChangingPassword"
-            />
-            <div class="py-2"></div>
-            <label class="sr-onlsy" for="input-withdrawal-amount">New password</label>
-            <input-password
-              v-model="newPassword"
-              ref="password"
-              inputGroupClass="neu-input-group"
-              inputClass="form-control form-control-lg neu-input w-100"
-              :disabled="isChangingPassword"
-            />
-            <div class="py-2"></div>
-            <label class="sr-onlsy" for="input-withdrawal-amount">Confirm new password</label>
-            <input-password
-              v-model="confirmNewPassword"
-              ref="password"
-              inputGroupClass="neu-input-group"
-              inputClass="form-control form-control-lg neu-input w-100"
-              :disabled="isChangingPassword"
-            />
-            <div class="py-2"></div>
-            <b-alert variant="warning" show>
-              <small>
-                ⚠ Remember, there is no "Forgot Password" button. If you lose
-                your password, you will have to recover your Umbrel using your 24
-                secret words.
-              </small>
-            </b-alert>
+        <card-widget header="Account" :loading="isChangingPassword">
+          <div class="pt-0">
+            <div class="d-flex w-100 justify-content-between px-3 px-lg-4 mb-4">
+              <div>
+                <span class="d-block">Password</span>
+                <small class="d-block" style="opacity: 0.4">Change the password of your Umbrel</small>
+              </div>
+
+              <b-button variant="outline-primary" size="sm" v-b-modal.change-password-modal>Change</b-button>
+
+              <b-modal id="change-password-modal" centered hide-footer>
+                <template v-slot:modal-header="{ close }">
+                  <div class="px-2 px-sm-3 pt-2 d-flex justify-content-between w-100">
+                    <h3>change password</h3>
+                    <!-- Emulate built in modal header close button action -->
+                    <a href="#" class="align-self-center" v-on:click.stop.prevent="close">
+                      <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 18 18"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          clip-rule="evenodd"
+                          d="M13.6003 4.44197C13.3562 4.19789 12.9605 4.19789 12.7164 4.44197L9.02116 8.1372L5.32596 4.442C5.08188 4.19792 4.68615 4.19792 4.44207 4.442C4.198 4.68607 4.198 5.0818 4.44207 5.32588L8.13728 9.02109L4.44185 12.7165C4.19777 12.9606 4.19777 13.3563 4.44185 13.6004C4.68592 13.8445 5.08165 13.8445 5.32573 13.6004L9.02116 9.90497L12.7166 13.6004C12.9607 13.8445 13.3564 13.8445 13.6005 13.6004C13.8446 13.3563 13.8446 12.9606 13.6005 12.7165L9.90505 9.02109L13.6003 5.32585C13.8444 5.08178 13.8444 4.68605 13.6003 4.44197Z"
+                          fill="#6c757d"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </template>
+                <div class="px-4 pb-2">
+                  <label class="sr-onlsy" for="input-withdrawal-amount">Current password</label>
+                  <input-password
+                    v-model="currentPassword"
+                    ref="password"
+                    inputGroupClass="neu-input-group"
+                    :inputClass="[ isIncorrectPassword ? 'incorrect-password' : '', 'form-control form-control-lg neu-input w-100']"
+                    :disabled="isChangingPassword"
+                  />
+                  <div class="py-2"></div>
+                  <label class="sr-onlsy" for="input-withdrawal-amount">New password</label>
+                  <input-password
+                    v-model="newPassword"
+                    ref="password"
+                    inputGroupClass="neu-input-group"
+                    inputClass="form-control form-control-lg neu-input w-100"
+                    :disabled="isChangingPassword"
+                  />
+                  <div class="py-2"></div>
+                  <label class="sr-onlsy" for="input-withdrawal-amount">Confirm new password</label>
+                  <input-password
+                    v-model="confirmNewPassword"
+                    ref="password"
+                    inputGroupClass="neu-input-group"
+                    inputClass="form-control form-control-lg neu-input w-100"
+                    :disabled="isChangingPassword"
+                  />
+                  <div class="py-2"></div>
+                  <b-alert variant="warning" show>
+                    <small>
+                      ⚠ Remember, there is no "Forgot Password" button. If you lose
+                      your password, you will have to recover your Umbrel using your 24
+                      secret words and channel backup.
+                    </small>
+                  </b-alert>
+                  <b-button
+                    class="w-100"
+                    variant="success"
+                    size="lg"
+                    :disabled="isChangingPassword || !isAllowedToChangePassword"
+                    @click="changePassword"
+                  >{{ isChangingPassword ? 'Changing password...' : 'Change password'}}</b-button>
+                </div>
+              </b-modal>
+            </div>
           </div>
-          <b-button
-            class="w-100"
-            variant="success"
-            style="border-radius: 0; border-bottom-left-radius: 1rem; border-bottom-right-radius: 1rem; padding-top: 1rem; padding-bottom: 1rem;"
-            :disabled="isChangingPassword || !isAllowedToChangePassword"
-            @click="changePassword"
-          >{{ isChangingPassword ? 'Changing password...' : 'Change password'}}</b-button>
         </card-widget>
       </b-col>
       <b-col col cols="12" md="6" xl="4">

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -126,7 +126,12 @@
                 <small class="d-block" style="opacity: 0.4">Change the password of your Umbrel</small>
               </div>
 
-              <b-button variant="outline-primary" size="sm" v-b-modal.change-password-modal>Change</b-button>
+              <b-button
+                variant="outline-primary"
+                size="sm"
+                v-b-modal.change-password-modal
+                :disabled="isChangingPassword"
+              >Change</b-button>
 
               <b-modal id="change-password-modal" centered hide-footer>
                 <template v-slot:modal-header="{ close }">


### PR DESCRIPTION
Clutter-free. Allows us to add more settings to this new "Account" card later, eg. change name, view seed, etc.

![image](https://user-images.githubusercontent.com/10330103/92589258-ef8aa800-f2b7-11ea-9918-8ad0ac3f952e.png)
