### PR TITLE
Improve visibility of ellipsis

### DIFF
--- a/src/components/CardWidget.vue
+++ b/src/components/CardWidget.vue
@@ -36,19 +36,19 @@
                     fill-rule="evenodd"
                     clip-rule="evenodd"
                     d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                    fill="#C3C6D1"
+                    fill="#6c757d"
                   />
                   <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
                     d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                    fill="#C3C6D1"
+                    fill="#6c757d"
                   />
                   <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
                     d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                    fill="#C3C6D1"
+                    fill="#6c757d"
                   />
                 </svg>
               </template>

--- a/src/views/Bitcoin.vue
+++ b/src/views/Bitcoin.vue
@@ -36,19 +36,19 @@
                 fill-rule="evenodd"
                 clip-rule="evenodd"
                 d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                fill="#C3C6D1"
+                fill="#6c757d"
               />
               <path
                 fill-rule="evenodd"
                 clip-rule="evenodd"
                 d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                fill="#C3C6D1"
+                fill="#6c757d"
               />
               <path
                 fill-rule="evenodd"
                 clip-rule="evenodd"
                 d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                fill="#C3C6D1"
+                fill="#6c757d"
               />
             </svg>
           </template>

--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -43,19 +43,19 @@
                   fill-rule="evenodd"
                   clip-rule="evenodd"
                   d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                  fill="#C3C6D1"
+                  fill="#6c757d"
                 />
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
                   d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                  fill="#C3C6D1"
+                  fill="#6c757d"
                 />
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
                   d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                  fill="#C3C6D1"
+                  fill="#6c757d"
                 />
               </svg>
             </template>


### PR DESCRIPTION
closes #132 

Tried black at first so they really stood out, but I think the "text-muted" color of `#6c757d` already in use elsewhere in the app looks a little better. 

<img width="448" alt="Screen Shot 2020-09-17 at 8 03 23 PM" src="https://user-images.githubusercontent.com/30157175/93540184-e1c0cc80-f920-11ea-9055-202a906f6bb9.png">
