### PR TITLE
Show peer address in the QR code instead of pubkey

### DIFF
--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -145,7 +145,7 @@
               <div class="d-flex align-items-center">
                 <!-- Pubkey QR Code -->
                 <qr-code
-                  :value="pubkey"
+                  :value="uris.length ? uris[0] : pubkey"
                   :size="180"
                   class="qr-image"
                   showLogo


### PR DESCRIPTION
Resolves #227. In case the hidden service url isn't available, it falls back to pubkey (eg. on a fresh start).