### PR TITLE
Seed improvements

### DIFF
--- a/src/components/Utility/Seed.vue
+++ b/src/components/Utility/Seed.vue
@@ -32,6 +32,7 @@
             class="neu-input"
             autofocus
             size="lg"
+            @keyup.enter="next"
           ></b-form-input>
         </div>
         <h2 class="text-center mb-0" v-else>

--- a/src/components/Utility/Seed.vue
+++ b/src/components/Utility/Seed.vue
@@ -117,7 +117,7 @@ export default {
       }
     },
     next() {
-      if (this.index < this.words.length) {
+      if (this.index < this.words.length - 1) {
         this.index += 1;
         // Autofocus input field if user is recovering
         if (this.recover) {

--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -338,6 +338,10 @@ export default {
       return (this.currentStep = this.currentStep + 1);
     },
     prevStep() {
+      if (this.currentStep === 5) {
+        this.notedSeed = false;
+      }
+
       this.currentStep = this.currentStep - 1;
     },
     finishedSeed() {

--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -87,7 +87,7 @@
           @click="nextStep"
           :disabled="!isStepValid || isRegistering"
           class="mt-3 mx-auto d-block px-4"
-          :class="{ 'loading-fade-blink': currentStep === 8 && !unlocked }"
+          :class="{ 'loading-fade-blink': currentStep === 8 && !unlocked, 'invisible': currentStep === 5 && recover && !isStepValid }"
         >{{ nextButtonText }}</b-button>
         <b-button
           variant="link"


### PR DESCRIPTION
The first two commits should be uncontroversial: When entering the seed the Enter key allows to proceed to the next word (in addition to clicking the button right to the input). 

While testing I found a case where navigating further is possible without completing the steps. If one goes to word 24 of thee seed page, uses the back button and then chooses to recover: Now the Next button is immediately enabled. The second commit fixes this.

The third commit can be considered optional and I can remove it from the PR if wanted: I found it to be confusing having the Next button present on the Recover page, especially since there are also the navigation buttons left and right to the input. Also the disabled state didn't seem obvious, so that I tried several times to go further using the Next button after entering a word.

My solution was to hide it until the recovery seed is fully entered. Until then it looks like this:

<img width="834" alt="recover" src="https://user-images.githubusercontent.com/886/94997822-f69e9080-05ad-11eb-8803-375fba772d1f.png">
