### PR TITLE
Set custom fee for on-chain transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbrel-dashboard",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -360,7 +360,7 @@
               <b class="d-block mt-3">{{ withdraw.address }}</b>
             </div>
             <div
-              class="w-100 text-center pb-3"
+              class="d-flex justify-content-between pb-3"
               v-if="withdraw.selectedFee.type === 'custom'"
             >
               <span class="text-muted">
@@ -370,8 +370,20 @@
                 <small>&nbsp;sat/vB</small>
                 <br />
                 <small>
+                  ~
+                  {{
+                    ((parseInt(fees.fast.total) / parseInt(fees.fast.perByte)) *
+                      parseInt(withdraw.selectedFee.satPerByte))
+                      | satsToUSD
+                  }}
                   Transaction fee
                 </small>
+              </span>
+              <span class="text-right text-muted">
+                <b>{{ projectedBalanceInSats | unit | localize }}</b>
+                <small>&nbsp;{{ unit | formatUnit }}</small>
+                <br />
+                <small>Remaining balance</small>
               </span>
             </div>
             <div class="d-flex justify-content-between pb-3" v-else>
@@ -673,7 +685,12 @@ export default {
 
         return remainingBalanceInSats;
       } else {
-        return "N/A";
+        const remainingBalanceInSats =
+          this.$store.state.bitcoin.balance.total -
+          this.withdraw.amount -
+          (parseInt(this.fees.fast.total) / parseInt(this.fees.fast.perByte)) *
+            parseInt(this.withdraw.selectedFee.satPerByte);
+        return remainingBalanceInSats;
       }
     }
   },

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -224,7 +224,7 @@
         >
           <div class="px-3 px-lg-4">
             <!-- Back Button -->
-            <div class="pt-1 pb-3">
+            <div class="pb-3">
               <a
                 href="#"
                 class="card-link text-muted"
@@ -273,7 +273,7 @@
                   ></sats-btc-switch>
                 </b-input-group-append>
               </b-input-group>
-              <div class="mt-1 w-100 d-flex justify-content-between">
+              <div class="w-100 d-flex justify-content-between">
                 <div></div>
                 <small
                   class="text-muted mt-1 d-block text-right mb-0"

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -372,8 +372,9 @@
                 <small>
                   ~
                   {{
-                    ((parseInt(fees.fast.total) / parseInt(fees.fast.perByte)) *
-                      parseInt(withdraw.selectedFee.satPerByte))
+                    ((parseInt(fees.fast.total, 10) /
+                      parseInt(fees.fast.perByte, 10)) *
+                      parseInt(withdraw.selectedFee.satPerByte, 10))
                       | satsToUSD
                   }}
                   Transaction fee
@@ -682,14 +683,15 @@ export default {
           this.$store.state.bitcoin.balance.total -
           this.withdraw.amount -
           this.fees[this.withdraw.selectedFee.type].total;
-        return parseInt(remainingBalanceInSats);
+        return parseInt(remainingBalanceInSats, 10);
       } else {
         const remainingBalanceInSats =
           this.$store.state.bitcoin.balance.total -
           this.withdraw.amount -
-          (parseInt(this.fees.fast.total) / parseInt(this.fees.fast.perByte)) *
-            parseInt(this.withdraw.selectedFee.satPerByte);
-        return parseInt(remainingBalanceInSats);
+          (parseInt(this.fees.fast.total, 10) /
+            parseInt(this.fees.fast.perByte, 10)) *
+            parseInt(this.withdraw.selectedFee.satPerByte, 10);
+        return parseInt(remainingBalanceInSats, 10);
       }
     }
   },
@@ -797,7 +799,7 @@ export default {
       const payload = {
         addr: this.withdraw.address,
         amt: this.withdraw.amount,
-        satPerByte: parseInt(this.withdraw.selectedFee.satPerByte),
+        satPerByte: parseInt(this.withdraw.selectedFee.satPerByte, 10),
         sendAll: this.withdraw.sweep
       };
 

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -682,15 +682,14 @@ export default {
           this.$store.state.bitcoin.balance.total -
           this.withdraw.amount -
           this.fees[this.withdraw.selectedFee.type].total;
-
-        return remainingBalanceInSats;
+        return parseInt(remainingBalanceInSats);
       } else {
         const remainingBalanceInSats =
           this.$store.state.bitcoin.balance.total -
           this.withdraw.amount -
           (parseInt(this.fees.fast.total) / parseInt(this.fees.fast.perByte)) *
             parseInt(this.withdraw.selectedFee.satPerByte);
-        return remainingBalanceInSats;
+        return parseInt(remainingBalanceInSats);
       }
     }
   },

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -1,12 +1,17 @@
 <template>
   <card-widget
     header="Bitcoin Wallet"
-    :status="{ text: lightningSyncPercent < 100 ? 'Synchronizing' : 'Active', variant: 'success', blink: false }"
+    :status="{
+      text: lightningSyncPercent < 100 ? 'Synchronizing' : 'Active',
+      variant: 'success',
+      blink: false
+    }"
     :sub-title="unit | formatUnit"
     icon="icon-app-bitcoin.svg"
     :loading="
       loading ||
-        (transactions.length > 0 && transactions[0]['type'] === 'loading') || lightningSyncPercent < 100
+        (transactions.length > 0 && transactions[0]['type'] === 'loading') ||
+        lightningSyncPercent < 100
     "
   >
     <template v-slot:title>
@@ -22,13 +27,21 @@
           }"
         />
       </div>
-      <span class="loading-placeholder loading-placeholder-lg" style="width: 140px;" v-else></span>
+      <span
+        class="loading-placeholder loading-placeholder-lg"
+        style="width: 140px;"
+        v-else
+      ></span>
     </template>
     <div class="wallet-content">
       <!-- transition switching between different modes -->
       <transition name="lightning-mode-change" mode="out-in" tag="div">
         <!-- Default Balance/tx screen -->
-        <div v-if="mode === 'transactions'" key="mode-balance" class="wallet-mode mode-balance">
+        <div
+          v-if="mode === 'transactions'"
+          key="mode-balance"
+          class="wallet-mode mode-balance"
+        >
           <!-- List of transactions -->
           <!-- No transactions -->
           <div
@@ -57,11 +70,16 @@
               />
             </svg>
 
-            <small class="align-self-center mt-3 text-muted">No transactions</small>
+            <small class="align-self-center mt-3 text-muted"
+              >No transactions</small
+            >
           </div>
 
           <div class="wallet-transactions-container" v-else>
-            <transition-group name="slide-up" class="list-group pb-2 transactions">
+            <transition-group
+              name="slide-up"
+              class="list-group pb-2 transactions"
+            >
               <!-- Transaction -->
               <b-list-group-item
                 v-for="tx in transactions"
@@ -71,23 +89,34 @@
                 target="_blank"
               >
                 <!-- Loading Transactions Placeholder -->
-                <div class="d-flex w-100 justify-content-between" v-if="tx.type === 'loading'">
+                <div
+                  class="d-flex w-100 justify-content-between"
+                  v-if="tx.type === 'loading'"
+                >
                   <div class="w-50">
                     <span class="loading-placeholder"></span>
 
                     <!-- Timestamp of tx -->
-                    <span class="loading-placeholder loading-placeholder-sm" style="width: 40%"></span>
+                    <span
+                      class="loading-placeholder loading-placeholder-sm"
+                      style="width: 40%"
+                    ></span>
                   </div>
 
                   <div class="w-25 text-right">
                     <span class="loading-placeholder"></span>
-                    <span class="loading-placeholder loading-placeholder-sm" style="width: 30%"></span>
+                    <span
+                      class="loading-placeholder loading-placeholder-sm"
+                      style="width: 30%"
+                    ></span>
                   </div>
                 </div>
 
                 <div class="d-flex w-100 justify-content-between" v-else>
                   <div class="transaction-description">
-                    <h6 class="mb-0 font-weight-normal transaction-description-text">
+                    <h6
+                      class="mb-0 font-weight-normal transaction-description-text"
+                    >
                       <!-- Incoming tx icon -->
                       <svg
                         width="18"
@@ -128,7 +157,9 @@
                       </svg>
 
                       <!-- tx description -->
-                      <span style="margin-left: 6px;" :title="tx.description">{{ tx.description }}</span>
+                      <span style="margin-left: 6px;" :title="tx.description">{{
+                        tx.description
+                      }}</span>
                     </h6>
 
                     <!-- Timestamp of tx -->
@@ -154,13 +185,15 @@
                           tx.description === 'Lightning Wallet' &&
                             tx.type === 'outgoing'
                         "
-                      >&bull; Channel open</span>
+                        >&bull; Channel open</span
+                      >
                       <span
                         v-else-if="
                           tx.description === 'Lightning Wallet' &&
                             tx.type === 'incoming'
                         "
-                      >&bull; Channel close</span>
+                        >&bull; Channel close</span
+                      >
                     </small>
                   </div>
 
@@ -184,11 +217,19 @@
         </div>
 
         <!-- SCREEN/MODE: Withdraw Screen -->
-        <div class="wallet-mode" v-else-if="mode === 'withdraw'" key="mode-withdraw">
+        <div
+          class="wallet-mode"
+          v-else-if="mode === 'withdraw'"
+          key="mode-withdraw"
+        >
           <div class="px-3 px-lg-4">
             <!-- Back Button -->
             <div class="pt-1 pb-3">
-              <a href="#" class="card-link text-muted" v-on:click.stop.prevent="reset">
+              <a
+                href="#"
+                class="card-link text-muted"
+                v-on:click.stop.prevent="reset"
+              >
                 <svg
                   width="7"
                   height="13"
@@ -205,7 +246,9 @@
               </a>
             </div>
             <div class="mb-0">
-              <label class="sr-onlsy" for="input-withdrawal-amount">Amount</label>
+              <label class="sr-onlsy" for="input-withdrawal-amount"
+                >Amount</label
+              >
               <b-input-group class="neu-input-group">
                 <b-input
                   id="input-withdrawal-amount"
@@ -219,7 +262,10 @@
                   :disabled="withdraw.sweep"
                 ></b-input>
                 <b-input-group-append class="neu-input-group-append">
-                  <sats-btc-switch class="align-self-center" size="sm"></sats-btc-switch>
+                  <sats-btc-switch
+                    class="align-self-center"
+                    size="sm"
+                  ></sats-btc-switch>
                 </b-input-group-append>
               </b-input-group>
               <div class="my-1 w-100 d-flex justify-content-between">
@@ -230,11 +276,14 @@
                 <small
                   class="text-muted mt-1 d-block text-right mb-0"
                   :style="{ opacity: withdraw.amount > 0 ? 1 : 0 }"
-                >~ {{ withdraw.amount | satsToUSD }}</small>
+                  >~ {{ withdraw.amount | satsToUSD }}</small
+                >
               </div>
             </div>
 
-            <label class="sr-onlsy" for="input-withdrawal-address">Address</label>
+            <label class="sr-onlsy" for="input-withdrawal-address"
+              >Address</label
+            >
             <b-input
               id="input-withdrawal-address"
               class="mb-2 neu-input"
@@ -246,7 +295,6 @@
             ></b-input>
           </div>
           <div class="px-3 px-lg-4 mt-1" v-show="!error">
-            <small class="text-muted d-block mb-0">Mining Fee</small>
             <fee-selector
               :fee="this.fees"
               :disabled="!withdraw.amount || !withdraw.address"
@@ -256,11 +304,19 @@
         </div>
 
         <!-- SCREEN/MODE: Review Withdrawal -->
-        <div class="wallet-mode" v-else-if="mode === 'review-withdraw'" key=" ode-review-withdraw">
+        <div
+          class="wallet-mode"
+          v-else-if="mode === 'review-withdraw'"
+          key=" ode-review-withdraw"
+        >
           <div class="px-3 px-lg-4">
             <!-- Back Button -->
             <div class="pt-2 pb-3">
-              <a href="#" class="card-link text-muted" v-on:click.stop.prevent="reset">
+              <a
+                href="#"
+                class="card-link text-muted"
+                v-on:click.stop.prevent="reset"
+              >
                 <svg
                   width="7"
                   height="13"
@@ -279,11 +335,11 @@
             <div class="text-center pb-4">
               <h3 class="mb-0">{{ withdraw.amount | unit | localize }}</h3>
               <span class="d-block mb-1 text-muted">
-                {{
-                unit | formatUnit
-                }}
+                {{ unit | formatUnit }}
               </span>
-              <small class="text-muted d-block mb-3">~ {{ withdraw.amount | satsToUSD }}</small>
+              <small class="text-muted d-block mb-3"
+                >~ {{ withdraw.amount | satsToUSD }}</small
+              >
 
               <svg
                 width="30"
@@ -301,19 +357,34 @@
 
               <b class="d-block mt-3">{{ withdraw.address }}</b>
             </div>
-            <div class="d-flex justify-content-between pb-3">
+            <div
+              class="w-100 text-center pb-3"
+              v-if="withdraw.selectedFee.type === 'custom'"
+            >
+              <span class="text-muted">
+                <b>
+                  {{ withdraw.selectedFee.satPerByte }}
+                </b>
+                <small>&nbsp;sat/vB</small>
+                <br />
+                <small>
+                  Transaction fee
+                </small>
+              </span>
+            </div>
+            <div class="d-flex justify-content-between pb-3" v-else>
               <span class="text-muted">
                 <b>
                   {{
-                  fees[withdraw.selectedFee]["total"] | unit | localize
+                    fees[withdraw.selectedFee.type]["total"] | unit | localize
                   }}
                 </b>
                 <small>&nbsp;{{ unit | formatUnit }}</small>
                 <br />
                 <small>
                   ~
-                  {{ fees[withdraw.selectedFee]["total"] | satsToUSD }} Mining
-                  fee
+                  {{ fees[withdraw.selectedFee.type]["total"] | satsToUSD }}
+                  Transaction fee
                 </small>
               </span>
               <span class="text-right text-muted">
@@ -335,7 +406,11 @@
           <div class="px-3 px-lg-4">
             <!-- Back Button -->
             <div class="pt-2 pb-3">
-              <a href="#" class="card-link text-muted" v-on:click.stop.prevent="reset">
+              <a
+                href="#"
+                class="card-link text-muted"
+                v-on:click.stop.prevent="reset"
+              >
                 <svg
                   width="7"
                   height="13"
@@ -379,7 +454,11 @@
           <div class="px-3 px-lg-4">
             <!-- Back Button -->
             <div class="pt-2 pb-3">
-              <a href="#" class="card-link text-muted" v-on:click.stop.prevent="reset">
+              <a
+                href="#"
+                class="card-link text-muted"
+                v-on:click.stop.prevent="reset"
+              >
                 <svg
                   width="7"
                   height="13"
@@ -403,10 +482,19 @@
             </p>
 
             <!-- Deposit Address QR Code -->
-            <qr-code class="mb-3" :value="depositAddress" :size="190" showLogo></qr-code>
+            <qr-code
+              class="mb-3"
+              :value="depositAddress"
+              :size="190"
+              showLogo
+            ></qr-code>
 
             <!-- Copy Address Input Field -->
-            <input-copy size="sm" :value="depositAddress" class="mb-4 mt-1"></input-copy>
+            <input-copy
+              size="sm"
+              :value="depositAddress"
+              class="mb-4 mt-1"
+            ></input-copy>
           </div>
         </div>
       </transition>
@@ -437,8 +525,8 @@
             <path
               d="M7.06802 4.71946C6.76099 4.71224 6.50825 4.96178 6.50627 5.27413C6.50435 5.57592 6.7539 5.82865 7.05534 5.83022L12.7162 5.86616L4.81508 13.3568C4.59632 13.5735 4.59981 14.1376 4.81615 14.3568C5.03249 14.5759 5.59723 14.572 5.81634 14.3556L13.4988 6.6587L13.4576 12.3143C13.4609 12.6214 13.7108 12.8745 14.0122 12.876C14.3246 12.878 14.5777 12.6281 14.574 12.3214L14.6184 5.32036C14.6257 5.01333 14.3761 4.76059 14.0694 4.76427L7.06802 4.71946Z"
               fill="#FFFFFF"
-            />
-          </svg>Withdraw
+            /></svg
+          >Withdraw
         </b-button>
         <b-button
           class="w-50"
@@ -457,8 +545,8 @@
             <path
               d="M13.5944 6.04611C13.6001 5.73904 13.3493 5.48755 13.0369 5.48712C12.7351 5.4867 12.4836 5.7375 12.4836 6.03895L12.4758 11.6999L4.94598 3.83615C4.72819 3.61848 4.16402 3.62477 3.94599 3.8422C3.72796 4.05963 3.73466 4.62433 3.95209 4.84236L11.6871 12.4864L6.03143 12.4733C5.72435 12.4782 5.47251 12.7293 5.47244 13.0308C5.47201 13.3431 5.72317 13.595 6.0299 13.5898L13.031 13.5994C13.3381 13.6051 13.5896 13.3543 13.5844 13.0476L13.5944 6.04611Z"
               fill="#FFFFFF"
-            />
-          </svg>Deposit
+            /></svg
+          >Deposit
         </b-button>
       </b-button-group>
       <b-button
@@ -470,7 +558,8 @@
         :disabled="
           !!error || !withdraw.amount || !withdraw.address || withdraw.isTyping
         "
-      >Review Withdrawal</b-button>
+        >Review Withdrawal</b-button
+      >
       <b-button
         class="w-100"
         variant="primary"
@@ -480,7 +569,7 @@
         v-else-if="mode === 'review-withdraw'"
       >
         {{
-        this.withdraw.isWithdrawing ? "Withdrawing..." : "Confirm Withdrawal"
+          this.withdraw.isWithdrawing ? "Withdrawing..." : "Confirm Withdrawal"
         }}
       </b-button>
       <b-button
@@ -503,8 +592,8 @@
           <path
             d="M7.06802 4.71946C6.76099 4.71224 6.50825 4.96178 6.50627 5.27413C6.50435 5.57592 6.7539 5.82865 7.05534 5.83022L12.7162 5.86616L4.81508 13.3568C4.59632 13.5735 4.59981 14.1376 4.81615 14.3568C5.03249 14.5759 5.59723 14.572 5.81634 14.3556L13.4988 6.6587L13.4576 12.3143C13.4609 12.6214 13.7108 12.8745 14.0122 12.876C14.3246 12.878 14.5777 12.6281 14.574 12.3214L14.6184 5.32036C14.6257 5.01333 14.3761 4.76059 14.0694 4.76427L7.06802 4.71946Z"
             fill="#FFFFFF"
-          />
-        </svg>View Transaction
+          /></svg
+        >View Transaction
       </b-button>
     </div>
   </card-widget>
@@ -539,7 +628,7 @@ export default {
         isTyping: false, //to disable button when the user changes amount/address
         isWithdrawing: false, //awaiting api response for withdrawal request?
         txHash: "", //tx hash of withdrawal tx,
-        selectedFee: "normal" //selected withdrawal fee
+        selectedFee: { type: "normal", satPerByte: 0 } //selected withdrawal fee
       },
       loading: false, //overall state of the wallet, used to toggle progress bar on top of the card,
       error: "" //used to show any error occured, eg. invalid amount, enter more than 0 sats, invoice expired, etc
@@ -574,12 +663,16 @@ export default {
         return 0;
       }
 
-      const remainingBalanceInSats =
-        this.$store.state.bitcoin.balance.total -
-        this.withdraw.amount -
-        this.fees[this.withdraw.selectedFee].total;
+      if (this.withdraw.selectedFee.type !== "custom") {
+        const remainingBalanceInSats =
+          this.$store.state.bitcoin.balance.total -
+          this.withdraw.amount -
+          this.fees[this.withdraw.selectedFee.type].total;
 
-      return remainingBalanceInSats;
+        return remainingBalanceInSats;
+      } else {
+        return "N/A";
+      }
     }
   },
   methods: {
@@ -629,7 +722,7 @@ export default {
         isTyping: false, //to disable button when the user changes amount/address
         isWithdrawing: false,
         txHash: "",
-        selectedFee: "normal"
+        selectedFee: { type: "normal", satPerByte: 0 }
       };
 
       this.loading = false;
@@ -660,10 +753,10 @@ export default {
           if (this.fees) {
             //show error if any
             if (
-              this.fees[this.withdraw.selectedFee] &&
-              this.fees[this.withdraw.selectedFee].error.code
+              this.fees[this.withdraw.selectedFee.type] &&
+              this.fees[this.withdraw.selectedFee.type].error.code
             ) {
-              this.error = this.fees[this.withdraw.selectedFee].error.text;
+              this.error = this.fees[this.withdraw.selectedFee.type].error.text;
             } else {
               this.error = "";
             }
@@ -686,7 +779,7 @@ export default {
       const payload = {
         addr: this.withdraw.address,
         amt: this.withdraw.amount,
-        satPerByte: parseInt(this.fees[this.withdraw.selectedFee].perByte),
+        satPerByte: parseInt(this.withdraw.selectedFee.satPerByte),
         sendAll: this.withdraw.sweep
       };
 

--- a/src/components/Channels/Manage.vue
+++ b/src/components/Channels/Manage.vue
@@ -6,12 +6,16 @@
           class="text-primary font-weight-bold"
           v-b-tooltip.hover.right
           :title="channel.localBalance | satsToUSD"
-        >{{ channel.localBalance | unit | localize }} {{ unit | formatUnit }}</h4>
+        >
+          {{ channel.localBalance | unit | localize }} {{ unit | formatUnit }}
+        </h4>
         <h4
           class="text-success font-weight-bold text-right"
           v-b-tooltip.hover.left
           :title="channel.remoteBalance | satsToUSD"
-        >{{ channel.remoteBalance | unit | localize }} {{ unit | formatUnit }}</h4>
+        >
+          {{ channel.remoteBalance | unit | localize }} {{ unit | formatUnit }}
+        </h4>
       </div>
       <bar
         :local="Number(channel.localBalance)"
@@ -27,25 +31,28 @@
 
     <transition name="mode-change" mode="out-in">
       <div v-if="!isReviewingChannelClose">
-        <div class="d-flex justify-content-between align-items-center mt-1 mb-3">
+        <div
+          class="d-flex justify-content-between align-items-center mt-1 mb-3"
+        >
           <span class="text-muted">Status</span>
-          <span class="text-capitalize font-weight-bold">{{ channel.status }}</span>
+          <span class="text-capitalize font-weight-bold">{{
+            channel.status
+          }}</span>
         </div>
 
         <div class="d-flex justify-content-between align-items-center mb-3">
           <span class="text-muted">Channel Type</span>
-          <span
-            class="text-capitalize font-weight-bold"
-          >{{ channel.private ? "Private" : "Public" }} Channel</span>
+          <span class="text-capitalize font-weight-bold"
+            >{{ channel.private ? "Private" : "Public" }} Channel</span
+          >
         </div>
 
         <div class="d-flex justify-content-between align-items-center mb-3">
           <span class="text-muted">Remote Peer Alias</span>
           <div class="w-75 text-right">
-            <span
-              class="font-weight-bold"
-              style="overflow-wrap: break-word;"
-            >{{ channel.remoteAlias }}</span>
+            <span class="font-weight-bold" style="overflow-wrap: break-word;">{{
+              channel.remoteAlias
+            }}</span>
           </div>
         </div>
 
@@ -54,9 +61,9 @@
           v-if="channel.status !== 'Closing'"
         >
           <span class="text-muted">Opened By</span>
-          <span
-            class="text-capitalize font-weight-bold"
-          >{{ channel.initiator ? "Your node" : "Remote peer" }}</span>
+          <span class="text-capitalize font-weight-bold">{{
+            channel.initiator ? "Your node" : "Remote peer"
+          }}</span>
         </div>
 
         <div class="d-flex justify-content-between align-items-center mb-3">
@@ -100,9 +107,9 @@
           v-if="channel.status === 'Online'"
         >
           <span class="text-muted">Withdrawal Timelock</span>
-          <span
-            class="text-capitalize font-weight-bold"
-          >{{ parseInt(channel.csvDelay).toLocaleString() }} Blocks</span>
+          <span class="text-capitalize font-weight-bold"
+            >{{ parseInt(channel.csvDelay).toLocaleString() }} Blocks</span
+          >
         </div>
 
         <div
@@ -122,12 +129,15 @@
             <small
               class="font-weight-bold"
               style="overflow-wrap: break-word;"
-            >{{ channel.remotePubkey }}</small>
+              >{{ channel.remotePubkey }}</small
+            >
           </div>
         </div>
 
         <div class="d-flex justify-content-end" v-if="canCloseChannel">
-          <b-button class="mt-2" variant="danger" @click="reviewChannelClose">Close Channel</b-button>
+          <b-button class="mt-2" variant="danger" @click="reviewChannelClose"
+            >Close Channel</b-button
+          >
         </div>
       </div>
 
@@ -136,7 +146,7 @@
         <p>
           Your local channel balance of
           <b>{{ parseInt(channel.localBalance).toLocaleString() }} Sats</b>
-          (excluding mining fee) will be returned to your Bitcoin wallet.
+          (excluding transaction fee) will be returned to your Bitcoin wallet.
         </p>
         <b-alert variant="warning" show>
           It may take upto 24 hours to close this channel if the remote peer is
@@ -151,7 +161,8 @@
             variant="danger"
             @click="confirmChannelClose"
             :disabled="isClosing"
-          >{{ isClosing ? "Closing Channel..." : "Confirm Close" }}</b-button>
+            >{{ isClosing ? "Closing Channel..." : "Confirm Close" }}</b-button
+          >
         </div>
       </div>
     </transition>

--- a/src/components/Channels/Open.vue
+++ b/src/components/Channels/Open.vue
@@ -164,11 +164,11 @@ export default {
 
       const payload = {
         amt: this.sweep
-          ? parseInt(this.fee[this.selectedFee.type].sweepAmount)
-          : parseInt(this.fundingAmount),
+          ? parseInt(this.fee[this.selectedFee.type].sweepAmount, 10)
+          : parseInt(this.fundingAmount, 10),
         name: "",
         purpose: "",
-        satPerByte: parseInt(this.selectedFee.satPerByte)
+        satPerByte: parseInt(this.selectedFee.satPerByte, 10)
       };
 
       const parsedConnectionCode = this.peerConnectionCode.match(

--- a/src/components/Channels/Open.vue
+++ b/src/components/Channels/Open.vue
@@ -55,7 +55,6 @@
     </b-row>
     <b-row>
       <b-col col cols="12" sm="6">
-        <small class="text-muted d-block mb-1">Mining Fee</small>
         <fee-selector :fee="fee" class @change="selectFee"></fee-selector>
       </b-col>
       <b-col class="d-flex" col cols="12" sm="6">
@@ -96,7 +95,10 @@ export default {
       fundingAmountInput: "",
       fundingAmount: 0,
       isOpening: false,
-      selectedFee: "normal",
+      selectedFee: {
+        type: "normal",
+        satPerByte: 0
+      },
       fee: {
         fast: {
           total: 0,
@@ -149,9 +151,12 @@ export default {
         return;
       }
 
-      if (this.fee[this.selectedFee].error) {
+      if (
+        this.selectedFee.type !== "custom" &&
+        this.fee[this.selectedFee.type].error
+      ) {
         this.isOpening = false;
-        this.error = this.fee[this.selectedFee].error;
+        this.error = this.fee[this.selectedFee.type].error;
         return;
       }
 
@@ -159,11 +164,11 @@ export default {
 
       const payload = {
         amt: this.sweep
-          ? parseInt(this.fee[this.selectedFee].sweepAmount)
+          ? parseInt(this.fee[this.selectedFee.type].sweepAmount)
           : parseInt(this.fundingAmount),
         name: "",
         purpose: "",
-        satPerByte: parseInt(this.fee[this.selectedFee].perByte)
+        satPerByte: parseInt(this.selectedFee.satPerByte)
       };
 
       const parsedConnectionCode = this.peerConnectionCode.match(

--- a/src/components/Utility/FeeSelector.vue
+++ b/src/components/Utility/FeeSelector.vue
@@ -25,7 +25,6 @@
         :max="customMaxFee"
         :interval="1"
         :dotSize="[22, 22]"
-        :tooltip-formatter="customFeeToolTipFormatter"
         contained
         :tooltip="
           fee.fast.total <= 0 ||
@@ -44,6 +43,26 @@
         @change="emitValue"
         key="custom-fee"
       >
+        <template v-slot:tooltip="{ value, focus }">
+          <div
+            :class="[
+              'vue-slider-dot-tooltip-inner vue-slider-dot-tooltip-inner-top',
+              { focus }
+            ]"
+          >
+            <span class="vue-slider-dot-tooltip-text d-block"
+              >{{ value }} sat/vB
+            </span>
+            <small class="text-muted"
+              >≈
+              {{
+                ((parseInt(fee.fast.total) / parseInt(fee.fast.perByte)) *
+                  value)
+                  | satsToUSD
+              }}</small
+            >
+          </div>
+        </template>
       </vue-slider>
       <div class="d-flex w-100 justify-content-between custom-fee-labels">
         <small class="text-muted mb-0">Slow</small>
@@ -57,7 +76,6 @@
         marks
         :data="data"
         :dotSize="[22, 22]"
-        :tooltip-formatter="tooltipFormatter"
         contained
         :tooltip="
           fee.fast.total <= 0 ||
@@ -79,6 +97,21 @@
         <template v-slot:label="{ active, value }">
           <div :class="['vue-slider-mark-label', 'text-center', { active }]">
             <span class="text-muted">~ {{ timeToConfirm(value) }}</span>
+          </div>
+        </template>
+        <template v-slot:tooltip="{ value, focus }">
+          <div
+            :class="[
+              'vue-slider-dot-tooltip-inner vue-slider-dot-tooltip-inner-top',
+              { focus }
+            ]"
+          >
+            <span class="vue-slider-dot-tooltip-text d-block mb-0"
+              >{{ fee[value].total }} Sats
+            </span>
+            <small class="text-muted"
+              >≈ {{ fee[value].total | satsToUSD }}</small
+            >
           </div>
         </template>
       </vue-slider>
@@ -111,10 +144,7 @@ export default {
       chosenFee: "normal",
       useCustomFee: false,
       customFee: 30,
-      data: ["cheapest", "slow", "normal", "fast"],
-      tooltipFormatter: value =>
-        `${Number(this.fee[value]["total"]).toLocaleString()} Sats`,
-      customFeeToolTipFormatter: value => `${value} sat/vB`
+      data: ["cheapest", "slow", "normal", "fast"]
     };
   },
   computed: {},
@@ -193,7 +223,7 @@ $labelFontSize: 0.8rem;
 @import "~vue-slider-component/lib/theme/default.scss";
 
 .vue-slider-container {
-  padding-top: 2rem;
+  padding-top: 3rem;
   padding-bottom: 1.5rem;
   margin-bottom: 1rem;
   position: relative;
@@ -254,6 +284,9 @@ $labelFontSize: 0.8rem;
 }
 
 .vue-slider-dot-tooltip-inner {
+  padding: 5px;
+  font-size: 0.75rem;
+  line-height: 1rem;
   box-shadow: 0 3px 15px rgba(0, 0, 0, 0.18);
 }
 

--- a/src/components/Utility/FeeSelector.vue
+++ b/src/components/Utility/FeeSelector.vue
@@ -107,7 +107,7 @@
             ]"
           >
             <span class="vue-slider-dot-tooltip-text d-block mb-0"
-              >{{ fee[value].total }} Sats
+              >{{ fee[value].perByte }} sat/vB
             </span>
             <small class="text-muted"
               >≈ {{ fee[value].total | satsToUSD }}</small

--- a/src/components/Utility/FeeSelector.vue
+++ b/src/components/Utility/FeeSelector.vue
@@ -56,7 +56,8 @@
             <small class="text-muted"
               >≈
               {{
-                ((parseInt(fee.fast.total) / parseInt(fee.fast.perByte)) *
+                ((parseInt(fee.fast.total, 10) /
+                  parseInt(fee.fast.perByte, 10)) *
                   value)
                   | satsToUSD
               }}</small
@@ -153,13 +154,13 @@ export default {
       if (this.useCustomFee) {
         const fee = {
           type: "custom",
-          satPerByte: parseInt(this.customFee)
+          satPerByte: parseInt(this.customFee, 10)
         };
         this.$emit("change", fee);
       } else {
         const fee = {
           type: this.chosenFee,
-          satPerByte: parseInt(this.fee[this.chosenFee].perByte)
+          satPerByte: parseInt(this.fee[this.chosenFee].perByte, 10)
         };
         this.$emit("change", fee);
       }


### PR DESCRIPTION
![umbrel-custom-fee](https://user-images.githubusercontent.com/10330103/95014209-088e3b00-0663-11eb-9898-89ea74a005c6.gif)

This PR makes it possible for the user to select a custom fee (denoted in sat/vB) for channel open and bitcoin withdrawal transactions.

Closes https://github.com/getumbrel/umbrel/issues/266