### PR TITLE
Add umbrel-dev.local as an allowed host to dev server

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,9 +8,11 @@ module.exports = {
   //         }
   //     }
   // }
-  // devServer: {
-  //     proxy: 'http://umbrel.local/',
-  // }
+  devServer: {
+    allowedHosts: [
+      'umbrel-dev.local',
+    ]
+  },
   chainWebpack: config => {
     config.plugin("html").tap(args => {
       args[0].template =


### PR DESCRIPTION
This is required to allow umbrel-dev access to the HMR WebSocket.