### PR TITLE
Add development Dockerfile for umbrel-dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:12-buster-slim
+
+# make the 'app' folder the current working directory
+WORKDIR /app
+
+# This is required to pick up filesystem changes in the VirtualBox
+# shared folder for hot module reload
+ENV CHOKIDAR_USEPOLLING=true
+
+# We need to make sure we build with production URLS so the NGINX proxy
+# in umbrel-dev routes them properly
+ENV VUE_APP_MIDDLEWARE_API_URL=/api
+ENV VUE_APP_MANAGER_API_URL=/manager-api
+
+EXPOSE 3004
+ENTRYPOINT ["bash"]
+CMD ["-c", "yarn && yarn vue-cli-service serve --port 3004"]


### PR DESCRIPTION
This adds an alternative Dockerfile to be used during development that support HMR.