### PR TITLE
Reduce QR logo size

### DIFF
--- a/src/components/Utility/QrCode.vue
+++ b/src/components/Utility/QrCode.vue
@@ -78,8 +78,8 @@ export default {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 35%;
-  height: 35%;
+  width: 25%;
+  height: 25%;
   transform: translate3d(-50%, -50%, 0) scale(1);
 }
 </style>


### PR DESCRIPTION
The logo was quite big which meant the scan error rate was very high. In Android QRs with a small amount of data such as Electrum or Bitcoin Core P2P connection details were practically impossible to scan.