### PR TITLE
Set fs poll interval to 1 second in dev Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,6 +6,7 @@ WORKDIR /app
 # This is required to pick up filesystem changes in the VirtualBox
 # shared folder for hot module reload
 ENV CHOKIDAR_USEPOLLING=true
+ENV CHOKIDAR_INTERVAL=1000
 
 # We need to make sure we build with production URLS so the NGINX proxy
 # in umbrel-dev routes them properly


### PR DESCRIPTION
We're polling for fs changes in the dev dockerfile instead of listening for fs events so it works reliable across VirtualBox/Docker volumes.

However in some cases (not always, not sure why) this results in really high CPU utilisation.

Setting the poll interval to 1000ms up from the default 100ms seems to alleviate this and is still fast enough for live reload.