### PR TITLE
Only render latest 6 block in DOM 

### DIFF
--- a/src/components/Blockchain.vue
+++ b/src/components/Blockchain.vue
@@ -140,9 +140,7 @@ export default {
       this.pollInProgress = true;
       //TODO: remove this timeout added so bitcoin can get fetch status first
       setTimeout(async () => {
-        window.requestAnimationFrame(async () => {
-          await this.$store.dispatch("bitcoin/getBlocks");
-        });
+        await this.$store.dispatch("bitcoin/getBlocks");
         this.pollInProgress = false;
       }, 1000);
     },

--- a/src/components/Blockchain.vue
+++ b/src/components/Blockchain.vue
@@ -128,8 +128,7 @@ export default {
   computed: {
     ...mapState({
       syncPercent: state => state.bitcoin.percent,
-      // Limit to 6 latest blocks
-      blocks: state => state.bitcoin.blocks.slice(0, 6)
+      blocks: state => state.bitcoin.blocks
     })
   },
   methods: {

--- a/src/components/Blockchain.vue
+++ b/src/components/Blockchain.vue
@@ -140,7 +140,9 @@ export default {
       this.pollInProgress = true;
       //TODO: remove this timeout added so bitcoin can get fetch status first
       setTimeout(async () => {
-        await this.$store.dispatch("bitcoin/getBlocks");
+        window.requestAnimationFrame(async () => {
+          await this.$store.dispatch("bitcoin/getBlocks");
+        });
         this.pollInProgress = false;
       }, 1000);
     },

--- a/src/components/Blockchain.vue
+++ b/src/components/Blockchain.vue
@@ -128,7 +128,8 @@ export default {
   computed: {
     ...mapState({
       syncPercent: state => state.bitcoin.percent,
-      blocks: state => state.bitcoin.blocks
+      // Limit to 6 latest blocks
+      blocks: state => state.bitcoin.blocks.slice(0, 6)
     })
   },
   methods: {

--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -118,7 +118,6 @@ const mutations = {
     const mergedBlocks = [...blocks, ...state.blocks];
     // remove duplicate blocks
     const uniqueBlocks = mergedBlocks.filter((v, i, a) => a.findIndex(t => (t.height === v.height)) === i);
-    
     state.blocks = uniqueBlocks;
   },
 

--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -118,7 +118,8 @@ const mutations = {
     const mergedBlocks = [...blocks, ...state.blocks];
     // remove duplicate blocks
     const uniqueBlocks = mergedBlocks.filter((v, i, a) => a.findIndex(t => (t.height === v.height)) === i);
-    state.blocks = uniqueBlocks;
+    // limit to latest 6 blocks
+    state.blocks = [...uniqueBlocks.slice(0, 6)];
   },
 
   setVersion(state, version) {

--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -118,7 +118,9 @@ const mutations = {
     const mergedBlocks = [...blocks, ...state.blocks];
     // remove duplicate blocks
     const uniqueBlocks = mergedBlocks.filter((v, i, a) => a.findIndex(t => (t.height === v.height)) === i);
-    state.blocks = uniqueBlocks;
+
+    // limit to latest 6 blocks
+    state.blocks = [...uniqueBlocks.slice(0, 6)];
   },
 
   setVersion(state, version) {
@@ -282,7 +284,7 @@ const actions = {
     }
   },
 
-  async getBlocks({ commit, state, dispatch }) {
+  async getBlocks({ commit, state, dispatch }) { 
     if (state.operational) {
       await dispatch("getSync");
 

--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -284,7 +284,7 @@ const actions = {
     }
   },
 
-  async getBlocks({ commit, state, dispatch }) { 
+  async getBlocks({ commit, state, dispatch }) {
     if (state.operational) {
       await dispatch("getSync");
 

--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -118,9 +118,8 @@ const mutations = {
     const mergedBlocks = [...blocks, ...state.blocks];
     // remove duplicate blocks
     const uniqueBlocks = mergedBlocks.filter((v, i, a) => a.findIndex(t => (t.height === v.height)) === i);
-
-    // limit to latest 6 blocks
-    state.blocks = [...uniqueBlocks.slice(0, 6)];
+    
+    state.blocks = uniqueBlocks;
   },
 
   setVersion(state, version) {


### PR DESCRIPTION
fixes #195 

Improve the performance of the block animation by:
- Limiting blocks in memory to 6 (that's all we should need for the animation)

