### PR TITLE
Warn users not to restart on slow Bitcoin startup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -158,7 +158,9 @@ export default {
 
       // Add slight delay so the progress bar makes
       // it to 100% before disappearing
-      setTimeout(() => (this.loading = false), 300);
+      await delay(300);
+      this.loading = false;
+      this.bitcoinStarted = false;
     }
   },
   created() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -118,7 +118,7 @@ export default {
         if (!this.bitcoinStarted) {
           this.bitcoinStarted = Date.now();
         } else if (Date.now() - this.bitcoinStarted > bitcoinSlowDelay) {
-           this.loadingText += " This can take a while, don't pull the power!";
+           this.loadingText += " This can take a while, please don't turn off your Umbrel!";
         }
 
         this.loadingProgress = 60;

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,7 @@ export default {
       loading: true,
       loadingText: "",
       loadingProgress: 0,
-      bitcoinStarted: 0,
+      bitcoinPollStarted: 0,
       loadingPollInProgress: false
     };
   },
@@ -115,9 +115,9 @@ export default {
 
         // Warn users against pulling power if Core is taking a while
         const bitcoinSlowDelay = 10 * SECONDS_IN_MS;
-        if (!this.bitcoinStarted) {
-          this.bitcoinStarted = Date.now();
-        } else if (Date.now() - this.bitcoinStarted > bitcoinSlowDelay) {
+        if (!this.bitcoinPollStarted) {
+          this.bitcoinPollStarted = Date.now();
+        } else if (Date.now() - this.bitcoinPollStarted > bitcoinSlowDelay) {
            this.loadingText += " This can take a while, please don't turn off your Umbrel!";
         }
 
@@ -129,7 +129,7 @@ export default {
           return;
         }
       }
-      this.bitcoinStarted = 0;
+      this.bitcoinPollStarted = 0;
 
       // Then check if lnd is operational
       if (this.loadingProgress <= 80) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,7 @@ export default {
       loading: true,
       loadingText: "",
       loadingProgress: 0,
-      bitcoinStarted: false,
+      bitcoinStarted: 0,
       loadingPollInProgress: false
     };
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,8 @@ import delay from "@/helpers/delay";
 import Shutdown from "@/components/Shutdown";
 import Loading from "@/components/Loading";
 
+const SECONDS_IN_MS = 1000;
+
 export default {
   name: "App",
   data() {
@@ -47,6 +49,7 @@ export default {
       loading: true,
       loadingText: "",
       loadingProgress: 0,
+      bitcoinStarted: false,
       loadingPollInProgress: false
     };
   },
@@ -109,6 +112,15 @@ export default {
       // Then check if btc is operational
       if (this.loadingProgress <= 60) {
         this.loadingText = "Loading Bitcoin Core...";
+
+        // Warn users against pulling power if Core is taking a while
+        const bitcoinSlowDelay = 10 * SECONDS_IN_MS;
+        if (!this.bitcoinStarted) {
+          this.bitcoinStarted = Date.now();
+        } else if (Date.now() - this.bitcoinStarted > bitcoinSlowDelay) {
+           this.loadingText += " This can take a while, don't pull the power!";
+        }
+
         this.loadingProgress = 60;
         await this.$store.dispatch("bitcoin/getStatus");
         if (!this.isBitcoinOperational) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -129,6 +129,7 @@ export default {
           return;
         }
       }
+      this.bitcoinStarted = 0;
 
       // Then check if lnd is operational
       if (this.loadingProgress <= 80) {
@@ -158,9 +159,7 @@ export default {
 
       // Add slight delay so the progress bar makes
       // it to 100% before disappearing
-      await delay(300);
-      this.loading = false;
-      this.bitcoinStarted = false;
+      setTimeout(() => (this.loading = false), 300);
     }
   },
   created() {


### PR DESCRIPTION
After an unclean shutdown sometimes Bitcoin Core needs to roll back blocks which can take quite a while. Sometimes users lose patience with the "Loading Bitcoin Core..." message and think something is stuck and just pull the power. This can (and has) caused more serious issues like filesystem corruption.

This change reassures the user if Bitcoin Core hasn't loaded after 10 seconds that this can sometimes take a while and asks them not to pull the power.

![bitcoin-loading](https://user-images.githubusercontent.com/2123375/98781410-d7a2e200-2428-11eb-904f-0a7f15499686.gif)
