### PR TITLE
Basic forwarding stats

### DIFF
--- a/src/components/LightningForwards.vue
+++ b/src/components/LightningForwards.vue
@@ -1,0 +1,80 @@
+<template>
+  <card-widget header="Weekly Forwarding">
+    <div class="px-3 px-lg-4">
+      <b-row>
+        <b-col col cols="6" xl="3">
+          <stat
+            title="Total Forwards"
+            :value="forwards.length"
+            showNumericChange
+          ></stat>
+        </b-col>
+        <b-col col cols="6" xl="3">
+          <stat
+            title="Total Inbound"
+            :value="totalInbound | unit"
+            :suffix="unit | formatUnit"
+          >
+          </stat>
+        </b-col>
+        <b-col col cols="6" xl="3">
+          <stat
+            title="Total Outbound"
+            :value="totalOutbound | unit"
+            :suffix="unit | formatUnit"
+          >
+          </stat>
+        </b-col>
+        <b-col col cols="6" xl="3">
+          <stat
+            title="Total Fees"
+            :value="totalFees | unit"
+            :suffix="unit | formatUnit"
+          >
+          </stat>
+        </b-col>
+      </b-row>
+    </div>
+  </card-widget>
+</template>
+
+<script>
+import { mapState } from "vuex";
+
+import CardWidget from "@/components/CardWidget";
+import Stat from "@/components/Utility/Stat";
+
+export default {
+  props: {},
+  computed: {
+    ...mapState({
+      forwards: state => state.lightning.forwards,
+      unit: state => state.system.unit
+    }),
+    totalInbound() {
+      return this.forwards.reduce((count, current) => {
+        return count + parseInt(current.amtIn);
+      }, 0);
+    },
+    totalOutbound() {
+      return this.forwards.reduce((count, current) => {
+        return count + parseInt(current.amtOut);
+      }, 0);
+    },
+    totalFees() {
+      return this.forwards.reduce((count, current) => {
+        return count + parseInt(current.fee);
+      }, 0);
+    }
+  },
+  methods: {},
+  watch: {},
+  async created() {
+    await this.$store.dispatch("lightning/getForwards");
+  },
+  components: {
+    CardWidget,
+    Stat
+  },
+};
+</script>

--- a/src/components/LightningForwards.vue
+++ b/src/components/LightningForwards.vue
@@ -1,6 +1,13 @@
 <template>
   <card-widget header="Weekly Forwarding">
-    <div class="px-3 px-lg-4">
+    <div class="px-3 px-lg-4" v-if="forwards.length === 0">
+      <p class="text-muted w-50 text-center mx-auto">
+        😢 No forwards this week
+        <br />
+        Hang tight and keep openning channels 🤩
+      </p>
+    </div>
+    <div class="px-3 px-lg-4" v-else>
       <b-row>
         <b-col col cols="6" xl="3">
           <stat
@@ -48,9 +55,12 @@ export default {
   props: {},
   computed: {
     ...mapState({
-      forwards: state => state.lightning.forwards,
-      unit: state => state.system.unit
+      // forwards: (state) => state.lightning.forwards,
+      unit: (state) => state.system.unit,
     }),
+    forwards() {
+      return [];
+    },
     totalInbound() {
       return this.forwards.reduce((count, current) => {
         return count + parseInt(current.amtIn);
@@ -65,7 +75,7 @@ export default {
       return this.forwards.reduce((count, current) => {
         return count + parseInt(current.fee);
       }, 0);
-    }
+    },
   },
   methods: {},
   watch: {},
@@ -74,7 +84,7 @@ export default {
   },
   components: {
     CardWidget,
-    Stat
+    Stat,
   },
 };
 </script>

--- a/src/components/LightningForwards.vue
+++ b/src/components/LightningForwards.vue
@@ -55,12 +55,9 @@ export default {
   props: {},
   computed: {
     ...mapState({
-      // forwards: (state) => state.lightning.forwards,
+      forwards: (state) => state.lightning.forwards,
       unit: (state) => state.system.unit,
     }),
-    forwards() {
-      return [];
-    },
     totalInbound() {
       return this.forwards.reduce((count, current) => {
         return count + parseInt(current.amtIn);

--- a/src/store/modules/lightning.js
+++ b/src/store/modules/lightning.js
@@ -1,5 +1,6 @@
 import API from "@/helpers/api";
 import { toPrecision } from "@/helpers/units";
+import moment from "moment";
 // import Events from '~/helpers/events';
 // import { sleep } from '@/helpers/utils';
 
@@ -58,7 +59,8 @@ const state = () => ({
   ],
   confirmedTransactions: [],
   pendingTransactions: [],
-  pendingChannelEdit: {}
+  pendingChannelEdit: {},
+  forwards: []
 });
 
 // Functions to update the state directly
@@ -147,6 +149,10 @@ const mutations = {
 
   setLndConnectUrls(state, urls) {
     state.lndConnectUrls = urls;
+  },
+
+  setForwards(state, forwards) {
+    state.forwards = forwards;
   }
 };
 
@@ -455,6 +461,21 @@ const actions = {
       if (result.status === 200) {
         commit("isUnlocked", true);
       }
+    }
+  },
+
+  async getForwards({ commit }) {
+    const startTime = moment()
+      .subtract(1, "week")
+      .unix();
+    const endTime = moment().unix();
+
+    const { forwardingEvents } = await API.get(
+      `${process.env.VUE_APP_MIDDLEWARE_API_URL}/v1/lnd/lightning/forwardingEvents?startTime=${startTime}&endTime=${endTime}`
+    );
+
+    if (forwardingEvents) {
+      commit("setForwards", forwardingEvents);
     }
   }
 };

--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -326,6 +326,11 @@
         </card-widget>
       </b-col>
     </b-row>
+    <b-row class="row-eq-height">
+      <b-col col cols="12" md="12" xl="8">
+        <lightning-forwards></lightning-forwards>
+      </b-col>
+    </b-row>
   </div>
 </template>
 
@@ -338,6 +343,7 @@ import CardWidget from "@/components/CardWidget";
 import Stat from "@/components/Utility/Stat";
 import LightningConnectWallet from "@/components/LightningConnectWallet";
 import LightningWallet from "@/components/LightningWallet";
+import LightningForwards from "@/components/LightningForwards";
 import QrCode from "@/components/Utility/QrCode";
 import InputCopy from "@/components/Utility/InputCopy";
 import ChannelList from "@/components/Channels/List";
@@ -419,6 +425,7 @@ export default {
   components: {
     LightningConnectWallet,
     LightningWallet,
+    LightningForwards,
     CardWidget,
     Stat,
     QrCode,


### PR DESCRIPTION
### What
- Some basic stats on node forwarding over the last week (could make this configurable when we have settings)

### Why
- I find myself looking in thunderhub or some other tool all the time wondering if my node has been up to anything
- I think this provides really nice feedback to the user to know that the node is doing something on the network

### How
- Hook into existing API to fetch forwarding events of the last week

## Screenshots
No forwards this week: 
![image](https://user-images.githubusercontent.com/21102414/99111361-e08be300-25e3-11eb-9c1a-19f848f0b1f1.png)

Some Forwards!:
![image](https://user-images.githubusercontent.com/21102414/99111400-f4cfe000-25e3-11eb-87f9-80a4f945c68e.png)

