### PR TITLE
Add warning on low inbound liquidity

### DIFF
--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -856,8 +856,8 @@ export default {
 
         this.$bvToast.toast(
           `
-            You will need more inbound capacity to receieve this. 
-            Try having other nodes open a channel with yours or spend some BTC over lightning.
+            You can receive a maximum of ${this.maxReceive.toLocaleString()} Sats through your payment channels. 
+            Increase your limit by getting other Lightning nodes to open channels with you.
           `,
           toastOptions
         );

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -844,7 +844,6 @@ export default {
     },
     async createInvoice() {
       // Check that there is enough liquidity to recieve
-      console.log(this.receive.amount, this.maxReceive);
       if (this.receive.amount > this.maxReceive) {
         const toastOptions = {
           title: "Error creating invoice",

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -848,14 +848,17 @@ export default {
       if (!this.maxRecieve || this.recieve.amount > this.maxRecieve) {
         const toastOptions = {
           title: "Low incoming balance",
-          autoHideDelay: 3000,
-          variant: "warning",
+          autoHideDelay: 6000,
+          variant: "danger",
           solid: true,
-          toaster: "b-toaster-top-center"
+          toaster: "b-toaster-top-full"
         };
 
         this.$bvToast.toast(
-          "You need more inbound capacity in order to recieve this payment. ",
+          `
+            You will need more inbound capacity to receieve this. 
+            Try having other nodes open a channel with yours or spend some BTC over lightning.
+          `,
           toastOptions
         );
 
@@ -863,7 +866,6 @@ export default {
       }
 
       //generate invoice to receive payment
-      this.showLowRecieveBalance = false;
       this.loading = true;
       this.receive.isGeneratingInvoice = true;
       this.mode = "invoice";
@@ -1136,5 +1138,9 @@ export default {
 .fade-enter,
 .fade-leave-to {
   opacity: 0;
+}
+
+.low-incoming-toast {
+  width: 60%;
 }
 </style>

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -845,7 +845,7 @@ export default {
     },
     async createInvoice() {
       // Check that there is enough in the recieve
-      if (!this.maxRecieve || this.receive.amount > this.maxRecieve) {
+      if (!this.maxRecieve || this.recieve.amount > this.maxRecieve) {
         const toastOptions = {
           title: "Low incoming balance",
           autoHideDelay: 3000,
@@ -855,7 +855,7 @@ export default {
         };
 
         this.$bvToast.toast(
-          "You need more inbound capacity in order to recieve a payment. ",
+          "You need more inbound capacity in order to recieve this payment. ",
           toastOptions
         );
 

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -847,7 +847,7 @@ export default {
       // Check that there is enough in the recieve
       if (!this.maxRecieve || this.recieve.amount > this.maxRecieve) {
         const toastOptions = {
-          title: "Low incoming balance",
+          title: "Error creating invoice",
           autoHideDelay: 3000,
           variant: "warning",
           solid: true,

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -725,8 +725,7 @@ export default {
         expiresOn: null //expiry date of the unpaid/expired invoice
       },
       loading: false, //overall state of the wallet. eg. used to toggle progress bar on top of the card,
-      error: "", //used to show any error occured, eg. invalid amount, enter more than 0 sats, invoice expired, etc
-      showLowRecieveBalance: false
+      error: "" //used to show any error occured, eg. invalid amount, enter more than 0 sats, invoice expired, etc
     };
   },
   props: {},
@@ -746,7 +745,7 @@ export default {
       },
       walletBalanceInSats: state => state.lightning.balance.total,
       unit: state => state.system.unit,
-      maxRecieve: state => state.lightning.maxRecieve
+      maxReceive: state => state.lightning.maxReceive
     }),
     isLightningPage() {
       return this.$router.currentRoute.path === "/lightning";
@@ -844,8 +843,9 @@ export default {
       this.send.isSending = false;
     },
     async createInvoice() {
-      // Check that there is enough in the recieve
-      if (!this.maxRecieve || this.recieve.amount > this.maxRecieve) {
+      // Check that there is enough liquidity to recieve
+      console.log(this.receive.amount, this.maxReceive);
+      if (this.receive.amount > this.maxReceive) {
         const toastOptions = {
           title: "Error creating invoice",
           autoHideDelay: 3000,
@@ -1138,9 +1138,5 @@ export default {
 .fade-enter,
 .fade-leave-to {
   opacity: 0;
-}
-
-.low-incoming-toast {
-  width: 60%;
 }
 </style>

--- a/src/components/LightningWallet.vue
+++ b/src/components/LightningWallet.vue
@@ -849,9 +849,9 @@ export default {
         const toastOptions = {
           title: "Error creating invoice",
           autoHideDelay: 3000,
-          variant: "warning",
+          variant: "danger",
           solid: true,
-          toaster: "b-toaster-top-center"
+          toaster: "b-toaster-bottom-right"
         };
 
         this.$bvToast.toast(


### PR DESCRIPTION
resolves https://github.com/getumbrel/umbrel-lightning/issues/14

### What? 
- Adds a toast message when creating an invoice if the max receive balance is lower than what the user is asking for in the invoice.
- Prevents the invoice from being created

### How? 
- Checks if maxRecieve is defined
- checks if maxRecieve is higher than the amount in the invoice

### Why? 
- As per some feedback from a user, they didn't know that they had to open some channels in order to receive

### What does it look like?
<img width="1436" alt="Screenshot 2020-11-28 at 18 50 44" src="https://user-images.githubusercontent.com/21102414/100523761-c426a380-31aa-11eb-9d82-7308647ae7ab.png">

