### PR TITLE
Only show "Download Channel Backup" if there are channels

### DIFF
--- a/src/layouts/DashboardLayout.vue
+++ b/src/layouts/DashboardLayout.vue
@@ -120,7 +120,7 @@
               <p class="text-newlines" v-if="availableUpdate.notes">
                 {{ availableUpdate.notes }}
               </p>
-              <b-alert variant="warning" show>
+              <b-alert variant="warning" show v-if="0 < numChannels">
                 <small
                   >Please download the latest backup of your payment channels
                   before updating and make sure to note down your 24 secret
@@ -214,6 +214,7 @@ export default {
     ...mapState({
       name: state => state.user.name,
       chain: state => state.bitcoin.chain,
+      numChannels: state => state.lightning.channels.length,
       availableUpdate: state => state.system.availableUpdate,
       updateStatus: state => state.system.updateStatus,
       showUpdateConfirmationModal: state =>

--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -192,9 +192,15 @@
           </template>
           <template v-slot:menu>
             <b-dropdown-item
+              v-if="0 < numChannels"
               href="#"
               @click.stop.prevent="downloadChannelBackup"
               >Download Channel Backup</b-dropdown-item
+            >
+            <b-dropdown-item
+              v-if="numChannels <= 0"
+              v-b-modal.open-channel-modal
+              >+ Open Channel</b-dropdown-item
             >
           </template>
           <div class>
@@ -363,6 +369,7 @@ export default {
       uris: state => state.lightning.uris,
       lndConnectUrls: state => state.lightning.lndConnectUrls,
       channels: state => state.lightning.channels,
+      numChannels: state => state.lightning.channels.length,
       unit: state => state.system.unit
     })
   },


### PR DESCRIPTION
This will satisfy issue Only show "Download Channel Backup" if there are channels #263 

I also added this on the lightning dropdown. If there are no channels then there also shouldn't be an option to backup the channels. An empty dropdown is also not desired so if there are no channels then the option to add a channel is available.