### PR TITLE
Fixed percent on Bitcoin synchronized value to always show 2 decimal places

### DIFF
--- a/src/views/Bitcoin.vue
+++ b/src/views/Bitcoin.vue
@@ -202,8 +202,14 @@
                 <span class="align-self-end">Synchronized</span>
                 <h3 class="font-weight-normal mb-0">
                   <span v-if="syncPercent !== -1">
-                    {{ syncPercent >= 99.99 ? 100 : syncPercent }}
-                    <small class>%</small>
+                    <CountUp
+                      :value="{
+                        endVal: syncPercent >= 99.99 ? 100 : syncPercent,
+                        decimalPlaces: syncPercent >= 99.99 ? 0 : 2
+                      }"
+                      suffix="%"
+                      v-if="syncPercent !== -1"
+                    />
                   </span>
 
                   <span
@@ -311,6 +317,7 @@ import InputCopy from "@/components/Utility/InputCopy";
 import Stat from "@/components/Utility/Stat";
 import BitcoinWallet from "@/components/BitcoinWallet";
 import BitcoinConnectWallet from "@/components/BitcoinConnectWallet";
+import CountUp from "@/components/Utility/CountUp";
 
 export default {
   data() {
@@ -372,6 +379,7 @@ export default {
     window.clearInterval(this.interval);
   },
   components: {
+    CountUp,
     CardWidget,
     Blockchain,
     QrCode,


### PR DESCRIPTION
I was watching my Synchronized percentage on the Bitcoin page and noticed that the percentage was not always 2 decimals.

I replaced it with a count up component to match the dashboard page. Now it always shows 2 decimal places.

Before 
![image](https://user-images.githubusercontent.com/19667830/101862516-c20bff80-3b2f-11eb-937a-a76413ad6c2e.png)

After
![image](https://user-images.githubusercontent.com/19667830/101862531-cafcd100-3b2f-11eb-851a-037fb1f6b291.png)
