### PR TITLE
Make .nav-vertical scrollable for screens with small height

### DIFF
--- a/src/components/AuthenticatedVerticalNavbar.vue
+++ b/src/components/AuthenticatedVerticalNavbar.vue
@@ -284,6 +284,7 @@ export default {
   // width: 280px;
   height: calc(var(--vh100, 100vh) - 82px);
   top: 82px;
+  overflow-y: auto;
   .nav-item {
     .nav-link {
       color: #141821;


### PR DESCRIPTION
Just a tiny CSS fix so that sidebar can stay scrollable on small screens.

Currently, without `overflow-y: auto` on `.nav-vertical`, App store and other options at the bottom of the sidebar remain inaccessible on small screens.