### PR TITLE
Base64 password to bypass passport issue

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -95,7 +95,7 @@ export default {
       this.isLoggingIn = true;
 
       try {
-        await this.$store.dispatch("user/login", this.password);
+        await this.$store.dispatch("user/login", btoa(this.password));
       } catch (error) {
         if (error.response && error.response.data === "Incorrect password") {
           this.isIncorrectPassword = true;
@@ -109,7 +109,7 @@ export default {
 
       if (!this.unlocked) {
         try {
-          await this.$store.dispatch("lightning/unlockWallet", this.password);
+          await this.$store.dispatch("lightning/unlockWallet", btoa(this.password));
         } catch (error) {
           if (error.response && error.response.data) {
             this.$bvToast.toast(`${error.response.data}`, {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -393,8 +393,8 @@ export default {
       }
 
       const payload = {
-        password: this.currentPassword,
-        newPassword: this.newPassword
+        password: btoa(this.currentPassword),
+        newPassword: btoa(this.newPassword)
       };
 
       this.isChangingPassword = true;

--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -275,7 +275,7 @@ export default {
         try {
           await this.$store.dispatch("user/register", {
             name: this.name,
-            password: this.password,
+            password: btoa(this.password),
             seed
           });
         } catch (error) {


### PR DESCRIPTION
This fix resolve https://github.com/getumbrel/umbrel/issues/424

The passwords are transformed in b64 with btoa to bypass the Passport issue who's splitting passwors with colon

Linked to https://github.com/getumbrel/umbrel-manager/pull/76
Linked to https://github.com/getumbrel/umbrel-middleware/pull/79

Thx @louneskmt @AaronDewes for the base64 tip