### PR TITLE
Use a local explorer app instead of mempool.space

### DIFF
--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -724,7 +724,10 @@ export default {
       if (this.localExplorerTxUrl) {
         return `${this.localExplorerTxUrl}${txHash}`;
       }
-      else { 
+      else {
+        if (window.location.origin.indexOf(".onion") > 0) {
+          return this.chain === "test" ? `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/tx/${txHash}` : `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/${txHash}`;
+        }
         return this.chain === "test" ? `https://mempool.space/testnet/tx/${txHash}` : `https://mempool.space/tx/${txHash}`;
       }
     },

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -14,7 +14,6 @@
         lightningSyncPercent < 100
     "
   >
-  {{ explorer }}
     <template v-slot:title>
       <div
         v-b-tooltip.hover.right
@@ -86,8 +85,9 @@
                 v-for="tx in transactions"
                 :key="tx.hash"
                 class="flex-column align-items-start px-3 px-lg-4"
-                href="#"
-                @click="openTxInExplorer(tx.hash)"
+                :href="getTxExplorerUrl(tx.hash)"
+                target="_blank"
+                @click="openTxInExplorer"
               >
                 <!-- Loading Transactions Placeholder -->
                 <div
@@ -594,8 +594,9 @@
         style="border-radius: 0; border-bottom-left-radius: 1rem; border-bottom-right-radius: 1rem; padding-top: 1rem; padding-bottom: 1rem;"
         :disabled="withdraw.isWithdrawing"
         v-else-if="mode === 'withdrawn'"
-        :href="getTxUrl(withdraw.txHash)"
+        :href="getTxExplorerUrl(withdraw.txHash)"
         target="_blank"
+        @click="openTxInExplorer"
       >
         <svg
           width="19"
@@ -719,18 +720,18 @@ export default {
     getReadableTime(timestamp) {
       return moment(timestamp).format("MMMM D, h:mm:ss a"); //used in the list of txs, eg "March 08, 2020 3:03:12 pm"
     },
-    openTxInExplorer(txHash) {
-      let url = "";
+    getTxExplorerUrl(txHash) {
       if (this.localExplorerTxUrl) {
-        url = `${this.localExplorerTxUrl}${txHash}`;
+        return `${this.localExplorerTxUrl}${txHash}`;
       }
-      else {
-        if (!window.confirm('This will open your transaction details in a public explorer (mempool.space). Do you wish to continue?')) {
-          return;
-        }
-        url = this.chain === "test" ? `https://mempool.space/testnet/tx/${txHash}` : `https://mempool.space/tx/${txHash}`;
+      else { 
+        return this.chain === "test" ? `https://mempool.space/testnet/tx/${txHash}` : `https://mempool.space/tx/${txHash}`;
       }
-      return window.open(url, '_blank');
+    },
+    openTxInExplorer(event) {
+      if (!this.localExplorerTxUrl && !window.confirm('This will open your transaction details in a public explorer (mempool.space). Do you wish to continue?')) {
+        event.preventDefault();
+      }
     },
     async changeMode(mode) {
       //change between different modes/screens of the wallet from - transactions (default), withdraw, withdrawan, depsoit

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -670,7 +670,7 @@ export default {
       fees: state => state.bitcoin.fees,
       unit: state => state.system.unit,
       chain: state => state.bitcoin.chain,
-      localExplorer: state => {
+      localExplorerTxUrl: state => {
         // Check for mempool app
         const mempool = state.apps.installed.find(({id}) => id === 'mempool');
         if (mempool) {
@@ -721,8 +721,8 @@ export default {
     },
     openTxInExplorer(txHash) {
       let url = "";
-      if (this.localExplorer) {
-        url = `${this.localExplorer}${txHash}`;
+      if (this.localExplorerTxUrl) {
+        url = `${this.localExplorerTxUrl}${txHash}`;
       }
       else {
         if (!window.confirm('This will open your transaction details in a public explorer (mempool.space). Do you wish to continue?')) {

--- a/src/components/BitcoinWallet.vue
+++ b/src/components/BitcoinWallet.vue
@@ -674,12 +674,7 @@ export default {
         // Check for mempool app
         const mempool = state.apps.installed.find(({id}) => id === 'mempool');
         if (mempool) {
-          let url = window.location.origin.indexOf(".onion") > 0 ? `http://${mempool.hiddenService}${mempool.path}` : `http://${window.location.hostname}:${mempool.port}${mempool.path}`;
-          if (this.chain === "test") {
-            url += "/testnet";
-          }
-          url += '/tx/';
-          return url;
+          return window.location.origin.indexOf(".onion") > 0 ? `http://${mempool.hiddenService}${mempool.path}/tx/` : `http://${window.location.hostname}:${mempool.port}${mempool.path}/tx/`;
         }
 
         // Check for btc-rpc-explorer app


### PR DESCRIPTION
- Use the mempool app if installed.
- If mempool isn't installed, use btc-rpc-explorer app.
- If btc-rpc-explorer isn't installed, warn the user before opening the public mempool.space.

Resolves https://github.com/getumbrel/umbrel/issues/488, resolves https://github.com/getumbrel/umbrel/issues/435, resolves https://github.com/getumbrel/umbrel-dashboard/issues/290, resolves https://github.com/getumbrel/umbrel-dashboard/issues/164.