### PR TITLE
Use `serve`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ EXPOSE 3004
 
 # -s rewrite all not-found requests to index.html
 # -l listen on 3004
-CMD [ "serve", "-s", "/dist" ]
+CMD [ "serve", "--single", "/dist" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,4 @@ COPY --from=umbrel-dashboard-builder /app/dist/ /dist
 ENV PORT=3004
 EXPOSE 3004
 
-# -s rewrite all not-found requests to index.html
-# -l listen on 3004
 CMD [ "serve", "--single", "/dist" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ RUN yarn global add serve
 
 COPY --from=umbrel-dashboard-builder /app/dist/ /dist
 
+ENV PORT=3004
 EXPOSE 3004
 
 # -s rewrite all not-found requests to index.html
 # -l listen on 3004
-CMD [ "serve", "-s", "-l", "3004", "/dist" ]
+CMD [ "serve", "-s", "/dist" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,15 @@ COPY . .
 # build app for production
 RUN yarn build
 
-# copy index.html to 404.html as http-server serves 404.html on all non "/" routes
-RUN cp ./dist/index.html ./dist/404.html
 
 FROM node:12-buster-slim AS umbrel-dashboard
 
-RUN yarn global add http-server
+RUN yarn global add serve
 
 COPY --from=umbrel-dashboard-builder /app/dist/ /dist
 
 EXPOSE 3004
-CMD [ "http-server", "-p 3004", "/dist" ]
+
+# -s rewrite all not-found requests to index.html
+# -l listen on 3004
+CMD [ "serve", "-s", "-l 3004", "/dist" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ EXPOSE 3004
 
 # -s rewrite all not-found requests to index.html
 # -l listen on 3004
-CMD [ "serve", "-s", "-l 3004", "/dist" ]
+CMD [ "serve", "-s", "-l", "3004", "/dist" ]


### PR DESCRIPTION
When using 404.html page as a fallback, `http-server` still returns a 404 status for `vue-router` pages.

This PR replaces `http-server` with [`serve`](https://www.npmjs.com/package/serve) that supports serving single page application.