### PR TITLE
Update Sparrow instructions for v1.1.0

### DIFF
--- a/src/components/ConnectWallet/Wallets/Sparrow.vue
+++ b/src/components/ConnectWallet/Wallets/Sparrow.vue
@@ -17,6 +17,11 @@
       <step>
         Disable <span class="font-weight-bold">"Use SSL"</span>.
       </step>
+      <b-alert class="mb-3" variant="info" show>
+        On Sparrow v1.1.0 and newer: if Tor is already running on your system, enable <span class="font-weight-bold">"Use Proxy"</span> and for <span class="font-weight-bold">"Proxy URL"</span>, enter
+        <input-copy class="my-1" value="127.0.0.1" auto-width></input-copy>
+        <input-copy class="my-1" value="9050" auto-width></input-copy>.
+      </b-alert>
       <step>
         Click <span class="font-weight-bold">"Test Connection"</span> to verify
         Sparrow is able to connect to your Umbrel.


### PR DESCRIPTION
Since Sparrow v1.1.0, Tor built-in can no longer work with Tor already installed on the system. This PR adds instructions to enable proxy and use the existing Tor proxy.

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/38882571/109082885-140efb00-7705-11eb-867b-b46c97831a12.png">

See: 
- https://github.com/sparrowwallet/sparrow/commit/e3d7bb57eec5aa14af3cb0ba20449f6ceba8479c
- https://github.com/sparrowwallet/sparrow/releases/tag/1.1.0