### PR TITLE
Disable referrer in HTTP requests

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="robots" content="noindex, nofollow" />
+  <meta name="referrer" content="no-referrer" />
   <link rel="icon" href="<%= BASE_URL %>favicon.png">
   <meta name="description" content="Welcome back">
 </head>


### PR DESCRIPTION
Resolves https://github.com/getumbrel/umbrel/issues/639

This disables setting the referrer header in HTTP requests. Setting the referrer is a privacy issue since it leaks the hidden service address to 3rd parties when visiting an external link.