### PR TITLE
Fix lightning address layout on small windows

### DIFF
--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -104,15 +104,15 @@
               </div>
             </template>
             <div class="px-2 px-sm-3 pb-2 pb-sm-3">
-              <div class="d-flex align-items-center">
+              <div class="d-lg-flex align-items-center">
                 <!-- Pubkey QR Code -->
                 <qr-code
                   :value="uris.length ? uris[0] : pubkey"
                   :size="180"
-                  class="qr-image mx-auto"
+                  class="qr-image mx-auto mb-3 mb-lg-0"
                   showLogo
                 ></qr-code>
-                <div class="w-100 align-self-center ml-3 ml-sm-4">
+                <div class="w-100 align-self-center ml-0 ml-lg-4">
                   <p>
                     Other Lightning nodes can open payment channels to your node
                     on the following address


### PR DESCRIPTION
Layout before change
<img width="360" alt="Screen Shot 2021-04-01 at 4 44 43 PM" src="https://user-images.githubusercontent.com/5139059/113361726-d146d100-9309-11eb-8926-e894222c15d0.png">

Layout after change
<img width="360" alt="Screen Shot 2021-04-01 at 4 45 05 PM" src="https://user-images.githubusercontent.com/5139059/113361703-c55b0f00-9309-11eb-82c2-575fba31603c.png">
