### PR TITLE
Remove LND unlock logic from dashboard

### DIFF
--- a/src/store/modules/lightning.js
+++ b/src/store/modules/lightning.js
@@ -444,18 +444,6 @@ const actions = {
     if (urls) {
       commit("setLndConnectUrls", urls);
     }
-  },
-
-  async unlockWallet({ commit, state }, plainTextPassword) {
-    if (state.operational && !state.unlocked) {
-      const result = await API.post(
-        `${process.env.VUE_APP_MIDDLEWARE_API_URL}/v1/lnd/wallet/unlock`,
-        { password: plainTextPassword }
-      );
-      if (result.status === 200) {
-        commit("isUnlocked", true);
-      }
-    }
   }
 };
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -104,28 +104,9 @@ export default {
         }
       }
 
-      //unlock lnd wallet if it's locked
+      // Fetch lnd status
       await this.$store.dispatch("lightning/getStatus");
-
       if (!this.unlocked) {
-        try {
-          await this.$store.dispatch("lightning/unlockWallet", this.password);
-        } catch (error) {
-          if (error.response && error.response.data) {
-            this.$bvToast.toast(`${error.response.data}`, {
-              title: "Error",
-              autoHideDelay: 3000,
-              variant: "danger",
-              solid: true,
-              toaster: "b-toaster-top-center"
-            });
-          }
-          this.isLoggingIn = false;
-          //logout user for safety
-          this.$store.dispatch("user/logout");
-          return;
-        }
-
         //redirect to dashboard once lnd is unlocked
         this.lndUnlockInterval = window.setInterval(async () => {
           await this.$store.dispatch("lightning/getStatus");


### PR DESCRIPTION
Related:
- https://github.com/getumbrel/umbrel-manager/pull/85
- https://github.com/getumbrel/umbrel-middleware/pull/82

This is no longer needed since we now auto unlock the LND wallet at boot time: https://github.com/getumbrel/umbrel-middleware/pull/82