### PR TITLE
Remove links to /logs page from dashboard

### DIFF
--- a/src/views/Bitcoin.vue
+++ b/src/views/Bitcoin.vue
@@ -25,46 +25,6 @@
             }}</span>
           </div>
         </div>
-        <b-dropdown
-          variant="link"
-          toggle-class="text-decoration-none p-0"
-          no-caret
-          right
-        >
-          <template v-slot:button-content>
-            <svg
-              width="18"
-              height="4"
-              viewBox="0 0 18 4"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                fill="#6c757d"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                fill="#6c757d"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                fill="#6c757d"
-              />
-            </svg>
-          </template>
-          <b-dropdown-item href="/logs/?filter=umbrel+bitcoin" target="_blank"
-            >View logs</b-dropdown-item
-          >
-          <!-- <b-dropdown-divider /> -->
-          <!-- <b-dropdown-item variant="danger" href="#" disabled>Stop Bitcoin Core</b-dropdown-item> -->
-        </b-dropdown>
       </div>
     </div>
 

--- a/src/views/Lightning.vue
+++ b/src/views/Lightning.vue
@@ -67,9 +67,6 @@
             <b-dropdown-item href="#" v-b-modal.lightning-address-modal
               >Lightning Address</b-dropdown-item
             >
-            <b-dropdown-item href="/logs/?filter=umbrel+lnd" target="_blank"
-              >View logs</b-dropdown-item
-            >
             <!-- <b-dropdown-divider /> -->
             <!-- <b-dropdown-item variant="danger" href="#" disabled>Stop LND</b-dropdown-item> -->
           </b-dropdown>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -3,37 +3,6 @@
     <div class="my-3 pb-2">
       <div class="d-flex justify-content-between align-items-center">
         <h1>settings</h1>
-        <b-dropdown variant="link" toggle-class="text-decoration-none p-0" no-caret right>
-          <template v-slot:button-content>
-            <svg
-              width="18"
-              height="4"
-              viewBox="0 0 18 4"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M2 4C3.10457 4 4 3.10457 4 2C4 0.89543 3.10457 0 2 0C0.89543 0 0 0.89543 0 2C0 3.10457 0.89543 4 2 4Z"
-                fill="#C3C6D1"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M9 4C10.1046 4 11 3.10457 11 2C11 0.89543 10.1046 0 9 0C7.89543 0 7 0.89543 7 2C7 3.10457 7.89543 4 9 4Z"
-                fill="#C3C6D1"
-              />
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M16 4C17.1046 4 18 3.10457 18 2C18 0.89543 17.1046 0 16 0C14.8954 0 14 0.89543 14 2C14 3.10457 14.8954 4 16 4Z"
-                fill="#C3C6D1"
-              />
-            </svg>
-          </template>
-          <b-dropdown-item href="/logs" target="_blank">View system logs</b-dropdown-item>
-        </b-dropdown>
       </div>
     </div>
 


### PR DESCRIPTION
The /logs page has been removed in https://github.com/getumbrel/umbrel/pull/718