### PR TITLE
Prevent Umbrel from running in an iframe

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
           </span>
         </div>
       </div>
-      <loading v-if="updating" :progress="updateStatus.progress">
+      <loading v-else-if="updating" :progress="updateStatus.progress">
         <div class="text-center">
           <small class="text-muted d-block">{{`${updateStatus.description}...`}}</small>
           <b-alert class="system-alert" variant="warning" show>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,14 @@
 <template>
   <div id="app">
     <transition name="loading" mode>
+      <div v-if="isIframe">
+        <div class="d-flex flex-column align-items-center justify-content-center min-vh100 p-2">
+          <img alt="Umbrel" src="@/assets/logo.svg" class="mb-5 logo" />
+          <span class="text-muted w-75 text-center">
+            <small>For security reasons Umbrel cannot be embedded in an iframe.</small>
+          </span>
+        </div>
+      </div>
       <loading v-if="updating" :progress="updateStatus.progress">
         <div class="text-center">
           <small class="text-muted d-block">{{`${updateStatus.description}...`}}</small>
@@ -44,6 +52,7 @@ export default {
   name: "App",
   data() {
     return {
+      isIframe: (self !== top),
       loading: true,
       loadingText: "",
       loadingProgress: 0,

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@ export default {
   name: "App",
   data() {
     return {
-      isIframe: (self !== top),
+      isIframe: (window.self !== window.top),
       loading: true,
       loadingText: "",
       loadingProgress: 0,


### PR DESCRIPTION
Resolves: https://github.com/getumbrel/umbrel/issues/728

This detects when Umbrel is running in an iframe and shows an error instead of rendering the application to prevent clickjacking attacks as described in the above issue.

<img width="1024" alt="Screenshot 2021-04-20 at 23 53 26" src="https://user-images.githubusercontent.com/2123375/115435049-a3331d80-a233-11eb-9867-609c2879aa57.png">

Thanks @Rubinoussoren!

**Note:** A more robust solution would be to serve the app with the `X-Frame-Options: DENY` HTTP header instead of relying on JavaScript to detect the existence of an iframe like in this PR. We should do both, but at the moment we don't have a proper server configuration committed to the dashboard codebase and just pull in a simple static server to the Docker image so this is fine for now.