### PR TITLE
Don't allow user creation process before LND is ready

### DIFF
--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -84,8 +84,8 @@
           @click="nextStep"
           :disabled="!isStepValid || isRegistering"
           class="mt-3 mx-auto d-block px-4"
-          :class="{ 'loading-fade-blink': currentStep === 8 && !unlocked, 'invisible': currentStep === 5 && recover && !isStepValid }"
-        >{{ nextButtonText }}</b-button>
+          :class="{ 'loading-fade-blink': !isLndOperational || (currentStep === 8 && !unlocked), 'invisible': currentStep === 5 && recover && !isStepValid }"
+        >{{ !isLndOperational ? "Loading" : nextButtonText }}</b-button>
         <b-button
           variant="link"
           size="sm"
@@ -118,6 +118,8 @@
 import Vue from "vue";
 import VueConfetti from "vue-confetti";
 import { mapState } from "vuex";
+
+import delay from "@/helpers/delay";
 
 import InputPassword from "@/components/Utility/InputPassword";
 import Seed from "@/components/Utility/Seed";
@@ -183,6 +185,7 @@ export default {
   },
   computed: {
     ...mapState({
+      isLndOperational: state => state.lightning.operational,
       registered: state => state.user.registered,
       seed: state => state.user.seed,
       unlocked: state => state.lightning.unlocked,
@@ -352,6 +355,12 @@ export default {
     //redirect to home if the user is already registered
     if (this.registered) {
       return this.$router.push("/");
+    }
+
+    // Wait for LND
+    while (!this.isLndOperational) {
+      await this.$store.dispatch("lightning/getStatus");
+      await delay(1000);
     }
 
     //generate a new seed on load


### PR DESCRIPTION
Now that the dashboard doesn't require LND or Bitcoin Core to be ready before loading the UI (https://github.com/getumbrel/umbrel-dashboard/pull/327) the user creation process can be ready before LND, which errors when it requests a seed phrase.

This PR adds a simple check, only in the user creation view, that shows the user a loading animation until LND is ready.