### PR TITLE
Disable click on setup loading button

### DIFF
--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -82,7 +82,7 @@
           variant="success"
           size="lg"
           @click="nextStep"
-          :disabled="!isStepValid || isRegistering"
+          :disabled="!isStepValid || isRegistering || !isLndOperational"
           class="mt-3 mx-auto d-block px-4"
           :class="{ 'loading-fade-blink': !isLndOperational || (currentStep === 8 && !unlocked), 'invisible': currentStep === 5 && recover && !isStepValid }"
         >{{ !isLndOperational ? "Loading" : nextButtonText }}</b-button>


### PR DESCRIPTION
Without this change the user can click the loading button to proceed with the setup process before LND is ready. This should have been included as part of https://github.com/getumbrel/umbrel-dashboard/pull/337.