### PR TITLE
feat:(changeUsername): Add UI and API call to enable user to change username in dashboard

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -61,6 +61,13 @@ const actions = {
     }
   },
 
+  async refreshName({ commit }) {
+    const { name } = await API.get(
+      `${process.env.VUE_APP_MANAGER_API_URL}/v1/account/info`
+    );
+    commit("setName", name);
+  },
+
   async registered({ commit }) {
     const { registered } = await API.get(
       `${process.env.VUE_APP_MANAGER_API_URL}/v1/account/registered`


### PR DESCRIPTION
This PR is being opened in order to support feature request #365

I have added the ability to update the Umbrel username from the dashboard settings page. Please see images below.

![umbrel-settings](https://user-images.githubusercontent.com/2151516/123804172-9c1f3000-d8b2-11eb-9693-c92aabbc9c8a.png)
![umbrel-change-username](https://user-images.githubusercontent.com/2151516/123804196-a04b4d80-d8b2-11eb-956e-9af7bc1e0a98.png)
![umbrel-username-changed](https://user-images.githubusercontent.com/2151516/123804206-a3ded480-d8b2-11eb-945b-a3b5635737d2.png)

This change is dependent on getumbrel/umbrel-manager#99 in order to be functional.

Feed back on code, as well as UI layout is welcome. Thanks!