### PR TITLE
Support Autofill Extensions for Password Inputs

### DIFF
--- a/src/components/Seed.vue
+++ b/src/components/Seed.vue
@@ -6,11 +6,8 @@
         v-model="password"
         ref="password"
         placeholder="Password"
-        inputGroupClass="neu-input-group"
-        :inputClass="[
-                    isIncorrectPassword ? 'incorrect-password' : '',
-                    'form-control form-control-lg neu-input w-100'
-                  ]"
+        displayStyle="FormStyle"
+        :displayInvalidAttempt="isIncorrectPassword"
         :disabled="isLoadingSeed"
       />
 

--- a/src/components/Utility/InputPassword.vue
+++ b/src/components/Utility/InputPassword.vue
@@ -1,16 +1,15 @@
 <template>
-  <b-input-group :class="inputGroupClass">
-    <!-- Todo: make it work with b-form-input + v-model -->
-    <input
-      :class="inputClass"
+  <b-input-group :class="[getGroupClassesByStyle, displayInvalidAttempt ? 'incorrect-password' : '']">
+    <b-form-input
+      :class="getInputClassesByStyle"
       :placeholder="placeholder"
       :type="showPassword ? 'text' : 'password'"
-      v-bind:value="value"
-      v-on:input="$emit('input', $event.target.value)"
+      :value="value"
+      @input="updateInputValue"
       :disabled="disabled"
     />
     <b-input-group-append>
-      <b-button @click="togglePassword" :disabled="disabled">
+      <b-button :class="getInputClassesByStyle" @click="togglePassword" :disabled="disabled">
         <b-icon :icon="showPassword ? 'eye-slash-fill' : 'eye-fill'"></b-icon>
       </b-button>
     </b-input-group-append>
@@ -18,13 +17,18 @@
 </template>
 
 <script>
+const CardStyle = "CardStyle";
+const FormStyle = "FormStyle";
 export default {
   props: {
     value: String,
-    inputClass: [String, Array],
-    inputGroupClass: {
+    displayInvalidAttempt: {
+      type: Boolean,
+      default: false
+    },
+    displayStyle: {
       type: String,
-      default: "card-input-group"
+      default: CardStyle
     },
     placeholder: String,
     disabled: {
@@ -35,7 +39,17 @@ export default {
   computed: {
     showPassword() {
       return this.state.showPassword;
-    }
+    },
+    getGroupClassesByStyle() {
+      return this.displayStyle === FormStyle
+        ? "form-input-group"
+        : "card-input-group";
+    },
+    getInputClassesByStyle() {
+      return this.displayStyle === FormStyle
+        ? "form-control-lg form-input-group-input btn-lg"
+        : "card-input-group-input";
+    },
   },
   data() {
     return {
@@ -47,9 +61,42 @@ export default {
   methods: {
     togglePassword() {
       return (this.state.showPassword = !this.state.showPassword);
+    },
+    updateInputValue: function(val) {
+      this.$emit("input", val);
     }
   }
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.incorrect-password {
+  animation: shake 1s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+  perspective: 1000px;
+}
+
+@keyframes shake {
+  10%,
+  90% {
+    transform: translate3d(-1px, 0, 0);
+  }
+
+  20%,
+  80% {
+    transform: translate3d(2px, 0, 0);
+  }
+
+  30%,
+  50%,
+  70% {
+    transform: translate3d(-4px, 0, 0);
+  }
+
+  40%,
+  60% {
+    transform: translate3d(4px, 0, 0);
+  }
+}
+</style>

--- a/src/global-styles/custom.scss
+++ b/src/global-styles/custom.scss
@@ -129,6 +129,48 @@ a {
     }
 }
   
+.form-input-group {
+    border-radius: 1rem;
+
+  .form-input-group-input {
+      box-shadow: inset 2px 7px 9px -7px rgba(0,0,0,0.2),  //top 
+                  inset 2px -7px 9px -7px rgba(0,0,0,0.2), //bottom 
+                  inset 5px 0 5px -7px rgba(0,0,0,0.2);    //left
+      border: none !important;  
+    }
+
+  .form-input-group-input:focus {
+      box-shadow: inset 3px 7px 9px -7px rgba(0,0,0,0.3),  //top 
+                  inset 3px -7px 9px -7px rgba(0,0,0,0.3), //bottom 
+                  inset 5px 0 5px -7px rgba(0,0,0,0.3);    //left
+      border: none !important;
+  }
+
+  .form-input-group-input:focus + .input-group-append > .btn-lg {
+    box-shadow: inset -3px 7px 9px -7px rgba(0,0,0,0.3),  //top
+                inset -3px -7px 9px -7px rgba(0,0,0,0.3), //bottom
+                inset -5px 0 5px -7px rgba(0,0,0,0.3)     //right
+                !important; 
+  }
+
+  .input-group-append {
+    margin-left: 0px;
+  }
+
+  .input-group-append > .btn-lg {
+    padding: 0.375rem 0.75rem;
+    color: #616877;
+    box-shadow: inset -2px 7px 9px -7px rgba(0,0,0,0.2),  //top
+                inset -2px -7px 9px -7px rgba(0,0,0,0.2), //bottom
+                inset -5px 0 5px -7px rgba(0,0,0,0.2)     //right
+               !important; 
+    background-color: unset;
+  }
+
+  .input-group-append > .btn-lg:active {
+    background-color: unset;
+  }
+}
 
 .dropdown-menu {
     background: #ffffff;
@@ -160,19 +202,33 @@ a {
 }
 
 .card-input-group {
-    .card-input {
-        padding-right: 3rem;
+    box-shadow: 0px 10px 30px rgba(209, 213, 223, 0.5);
+    border-radius: 1rem;
+
+    &:hover,
+    &:focus,
+    &:active {
+      box-shadow: 0px 10px 40px rgba(209, 213, 223, 0.9);
     }
+
+    .card-input-group-input {
+        -webkit-appearance: none; //iOS messes up forms - See: https://stackoverflow.com/questions/10757146/iphone-ios-will-not-display-box-shadow-properly
+        border-radius: 1rem;
+        height: calc(2.25em + 1.125rem + 2px);
+        padding: 0.5rem 1rem;
+        outline: 0 !important;
+        border: none !important;
+
+        &:hover,
+        &:focus,
+        &:active {
+            box-shadow: none;
+        }
+    }
+    
     .input-group-append > .btn {
-        background: none !important;
         color: #616877;
-        border: none !important;    
-        outline: none !important;
-        box-shadow: none !important;
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        right: 0.5rem;
+        background-color: #ffffff !important;
     }
 }
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -21,10 +21,8 @@
           v-model="password"
           ref="password"
           placeholder="Password"
-          :inputClass="[
-            isIncorrectPassword ? 'incorrect-password' : '',
-            'card-input w-100'
-          ]"
+          formStyle="CardInput"
+          :displayInvalidAttempt="isIncorrectPassword"
           :disabled="isLoggingIn"
         />
         <div class="login-button-container">
@@ -140,36 +138,6 @@ export default {
     bottom: 0;
     left: 50%;
     transform: translate3d(-50%, 0, 0);
-  }
-}
-
-.incorrect-password {
-  animation: shake 1s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
-  perspective: 1000px;
-}
-
-@keyframes shake {
-  10%,
-  90% {
-    transform: translate3d(-1px, 0, 0);
-  }
-
-  20%,
-  80% {
-    transform: translate3d(2px, 0, 0);
-  }
-
-  30%,
-  50%,
-  70% {
-    transform: translate3d(-4px, 0, 0);
-  }
-
-  40%,
-  60% {
-    transform: translate3d(4px, 0, 0);
   }
 }
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -173,8 +173,8 @@
                   <input-password
                     v-model="currentPassword"
                     ref="password"
-                    inputGroupClass="neu-input-group"
-                    :inputClass="[ isIncorrectPassword ? 'incorrect-password' : '', 'form-control form-control-lg neu-input w-100']"
+                    displayStyle="FormStyle"
+                    :displayInvalidAttempt="isIncorrectPassword"
                     :disabled="isChangingPassword"
                   />
                   <div class="py-2"></div>
@@ -182,8 +182,7 @@
                   <input-password
                     v-model="newPassword"
                     ref="password"
-                    inputGroupClass="neu-input-group"
-                    inputClass="form-control form-control-lg neu-input w-100"
+                    displayStyle="FormStyle"
                     :disabled="isChangingPassword"
                   />
                   <div class="py-2"></div>
@@ -191,8 +190,7 @@
                   <input-password
                     v-model="confirmNewPassword"
                     ref="password"
-                    inputGroupClass="neu-input-group"
-                    inputClass="form-control form-control-lg neu-input w-100"
+                    displayStyle="FormStyle"
                     :disabled="isChangingPassword"
                   />
                   <div class="py-2"></div>

--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -20,7 +20,7 @@
           ref="password"
           v-show="currentStep === 2"
           placeholder="Your password"
-          inputClass="card-input w-100"
+          displayStyle="CardInput"
         />
 
         <input-password
@@ -28,7 +28,7 @@
           ref="confirmPassword"
           placeholder="Re-enter your password"
           v-show="currentStep === 3"
-          inputClass="card-input w-100"
+          displayStyle="CardInput"
         />
 
         <div v-show="currentStep === 5">


### PR DESCRIPTION
This PR is being opened to resolve issue #322.

The issue was that the password inputs had broken CSS and form grouping which caused LastPass (for example) to overlap with the show/hide button.

I have refactored the password-input component to properly group inputs. Additionally, I have refactored the styling of this component to try and make it more self contained. With the addition of the `displayStyle` prop, the parent can now dictate a style preference without needing to know the implementation details required to properly style the child component.

Please let me know if there is any feedback on these changes. This update has been tested locally in my environment in Chrome and FireFox.

Here is what the refactored inputs look like now:

![login-password](https://user-images.githubusercontent.com/2151516/124063898-718bbf00-d9f9-11eb-9cdb-f103e494ac2a.png)
![change-password](https://user-images.githubusercontent.com/2151516/124063906-73558280-d9f9-11eb-9884-9413a1625af5.png)
