### PR TITLE
Use Roboto font on non-Apple devices

### DIFF
--- a/src/global-styles/_variables.scss
+++ b/src/global-styles/_variables.scss
@@ -7,7 +7,7 @@ $red: #F46E6E;
 $white: #ffffff;
 $spacer: 1.5rem;
 $body-color: $black;
-$font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", "Segoe UI", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Roboto", "Helvetica Neue", "Segoe UI", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 $h1-font-size: $font-size-base * 5;
 $h2-font-size: $font-size-base * 3;
 $h3-font-size: $font-size-base * 2;


### PR DESCRIPTION
System fonts on Windows and Ubuntu look terrible. This PR changes the font to Roboto on non-Apple installs, the closest looking font to San Francisco typeface.