### PR TITLE
Fix small typo

### DIFF
--- a/src/components/ConnectWallet/Wallets/Sparrow.vue
+++ b/src/components/ConnectWallet/Wallets/Sparrow.vue
@@ -7,7 +7,7 @@
         <span class="font-weight-bold">Preferences > Server</span>.
       </step>
       <step>
-        In the <span class="font-weight-bold">"Type"</span>, select <span class="font-weight-bold">"Private Electrum Server"</span>
+        In the <span class="font-weight-bold">"Type"</span>, select <span class="font-weight-bold">"Private Electrum"</span>
       </step>
       <step>
         For <span class="font-weight-bold">"URL"</span>, enter

--- a/src/components/ConnectWallet/Wallets/Sparrow.vue
+++ b/src/components/ConnectWallet/Wallets/Sparrow.vue
@@ -7,7 +7,7 @@
         <span class="font-weight-bold">Preferences > Server</span>.
       </step>
       <step>
-        In the <span class="font-weight-bold">"Type"</span>, select <span class="font-weight-bold">"Electrum Server"</span>
+        In the <span class="font-weight-bold">"Type"</span>, select <span class="font-weight-bold">"Private Electrum Server"</span>
       </step>
       <step>
         For <span class="font-weight-bold">"URL"</span>, enter


### PR DESCRIPTION
When setting up Sparrow to connect to Umbrel, there's a small typo on type of server. 

This PR fixes that. 

![image](https://user-images.githubusercontent.com/7484829/144756115-7838b0db-a305-46af-a6b7-fe95b1e1dfb0.png)
