### PR TITLE
Seed setup hotfix

### DIFF
--- a/src/views/Start.vue
+++ b/src/views/Start.vue
@@ -364,7 +364,7 @@ export default {
     }
 
     //generate a new seed on load
-    this.$store.dispatch("user/getSeed");
+    this.$store.dispatch("user/getSeed", { password: "", otpToken: "" });
   },
   beforeDestroy() {
     window.clearInterval(this.lndUnlockInterval);


### PR DESCRIPTION
After https://github.com/getumbrel/umbrel-dashboard/pull/398, `"user/getSeed"` action now accepts a JSON parameter, which is why it errored out if expected keys were missing.