### PR TITLE
fix rounding in satsToUSD view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,11 +43,12 @@ Vue.filter("satsToUSD", value => {
   if (isNaN(parseInt(value))) {
     return value;
   } else {
-    return (
-      "$" +
-      Number(
-        (satsToBtc(value) * store.state.bitcoin.price).toFixed(2)
-      ).toLocaleString()
+    return Number(satsToBtc(value) * store.state.bitcoin.price).toLocaleString(
+      Intl.NumberFormat().resolvedOptions().locale,
+      {
+        currency: "usd",
+        style: "currency"
+      }
     );
   }
 });


### PR DESCRIPTION
This pull request fixes an issue with the USD balance view on the dashboard. 

Essentially, the rounding is done in a way where the USD value can round to a single decimal place, even though USD values are properly represented with two decimal places.

<img width="285" alt="Screen Shot 2022-01-06 at 12 22 04 AM" src="https://user-images.githubusercontent.com/4824042/148332719-a6a8de3e-5531-401c-ac4d-390e40435baf.png">

This is essentially the logic that exists today:

```
"$" + Number(150.1.toFixed(2)).toLocaleString()
```

The problem with this is that casting to `Number()` removes the attempt at pinning the number of decimals via `.toFixed()`.

The solution is to use `Number`s native currency styling support:

```
Number("150.1").toLocaleString(Intl.NumberFormat().resolvedOptions().locale, {currency: 'usd', style: 'currency'})
```

Then it looks correct

![image](https://user-images.githubusercontent.com/4824042/148333162-eed8aca1-45c3-46d2-948d-998457bc80e4.png)


