### PR TITLE
Use window.location.origin to create InstalledApp url

### DIFF
--- a/src/components/InstalledApp.vue
+++ b/src/components/InstalledApp.vue
@@ -166,7 +166,7 @@ export default {
         if (this.torOnly) {
           return "#";
         }
-        return `http://${window.location.hostname}:${this.app.port}${this.app.path}`;
+        return `${window.location.origin}:${this.app.port}${this.app.path}`;
       }
     },
     dependants: function() {

--- a/src/components/InstalledApp.vue
+++ b/src/components/InstalledApp.vue
@@ -166,7 +166,7 @@ export default {
         if (this.torOnly) {
           return "#";
         }
-        return `${window.location.origin}:${this.app.port}${this.app.path}`;
+        return `${window.location.protocol}//${window.location.hostname}:${this.app.port}${this.app.path}`;
       }
     },
     dependants: function() {


### PR DESCRIPTION
Previously, the code used http://${window.location.hostname} to build
the base URL for checking the status of an app. Now it uses
${window.location.origin}.

In my case, I have set up nginx as a reverse proxy in order to use TLS
encryption for my node. I am accessing Umbrel via https:// now. As a
result, the functionality to check the status of services was not
working due to the browser blocking mixed content requests.

I have not actually tested this code, as I don't have a development environment set up for Umbrel. I'm hoping someone else can test or this is straightforward enough to include. 