### PR TITLE
Select password input field on login page load and wrong password input

### DIFF
--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -109,6 +109,7 @@ export default {
     }
 
     this.loading = false;
+    this.selectPasswordInput();
   },
   methods: {
     async authenticateUser() {
@@ -120,6 +121,7 @@ export default {
         this.isLoggingIn = false;
         if (error.response && error.response.data === "Incorrect password") {
           this.isIncorrectPassword = true;
+          this.selectPasswordInput();
           return;
         }
         if (error.response && error.response.data === "Missing OTP token") {
@@ -159,6 +161,10 @@ export default {
       return this.$router.push(
         this.$router.history.current.query.redirect || {name: 'home'}
       );
+    },
+    selectPasswordInput() {
+      console.log(this.$refs)
+      this.$nextTick(() => this.$refs.password.$el.querySelector('input').select());
     },
     authenticateUserWithOtp(otpToken) {
       this.otpToken = otpToken;

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -163,7 +163,6 @@ export default {
       );
     },
     selectPasswordInput() {
-      console.log(this.$refs)
       this.$nextTick(() => this.$refs.password.$el.querySelector('input').select());
     },
     authenticateUserWithOtp(otpToken) {


### PR DESCRIPTION
As described in #429 

`$nextTick` was used, otherwise the query selector is too fast for the DOM
`$el.querySelector('input')` is used on `$refs.password`, because the `<input-password>` tag splits into a `<div>` and `<input>` tag where `ref="password"` is put on the `<div>` tag, while `select()` is needed on the `<input>` tag