### PR TITLE
Fix dock hover wobble

### DIFF
--- a/src/components/DockApp.vue
+++ b/src/components/DockApp.vue
@@ -58,7 +58,7 @@ export default {
   width: 60px;
   height: 60px;
   transition: margin 0.3s, transform 0.3s ease;
-  margin: 0 6px;
+  margin: 0 8px;
 
   .dock-app {
     &:after {
@@ -194,7 +194,6 @@ export default {
 @media (hover: hover) and (pointer: fine) {
   .dock-app-container {
     &:hover {
-      margin: 0px 15px;
       .dock-app-name  {
         visibility: visible;
       }

--- a/src/components/DockApp.vue
+++ b/src/components/DockApp.vue
@@ -58,7 +58,7 @@ export default {
   width: 60px;
   height: 60px;
   transition: margin 0.3s, transform 0.3s ease;
-  margin: 0 8px;
+  margin: 0 6px;
 
   .dock-app {
     &:after {
@@ -199,7 +199,7 @@ export default {
       }
     }
     .dock-app-icon-container:hover {
-      transform: scale3d(1.3, 1.3, 1.3) translate3d(0, -10px, 0);
+      transform: scale3d(1.2, 1.2, 1.2) translate3d(0, -10px, 0);
     }
     &.dock-app-container-left {
       &:hover {


### PR DESCRIPTION
Gets rid of the wobble effect when hovering over a dock icon. Also increases the horizontal margin by between icons by 2px so that they don't touch when the hover transform happens.